### PR TITLE
Collects Outgoing Intent ID from route parameter for new Message Templates

### DIFF
--- a/app/Http/Controllers/API/MessageTemplatesController.php
+++ b/app/Http/Controllers/API/MessageTemplatesController.php
@@ -7,6 +7,7 @@ use App\Http\Resources\MessageTemplateCollection;
 use App\Http\Resources\MessageTemplateResource;
 use Illuminate\Http\Request;
 use OpenDialogAi\ResponseEngine\MessageTemplate;
+use OpenDialogAi\ResponseEngine\OutgoingIntent;
 use OpenDialogAi\ResponseEngine\Rules\MessageConditions;
 use OpenDialogAi\ResponseEngine\Rules\MessageXML;
 
@@ -35,12 +36,18 @@ class MessageTemplatesController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param $outgoingIntentId
+     * @param \Illuminate\Http\Request $request
      * @return \Illuminate\Http\Response
      */
-    public function store(Request $request)
+    public function store($outgoingIntentId, Request $request)
     {
+        if (!OutgoingIntent::find($outgoingIntentId)) {
+            return response("The requested Outgoing Intent ID does not exist.", 404);
+        }
+
         $messageTemplate = MessageTemplate::make($request->all());
+        $messageTemplate->outgoing_intent_id = $outgoingIntentId;
 
         if ($error = $this->validateValue($messageTemplate)) {
             return response($error, 400);

--- a/app/Http/Controllers/API/MessageTemplatesController.php
+++ b/app/Http/Controllers/API/MessageTemplatesController.php
@@ -129,6 +129,12 @@ class MessageTemplatesController extends Controller
             ];
         }
 
+        if (!$messageTemplate->outgoing_intent_id) {
+            return [
+                'message' => 'Outgoing Intent ID is required.',
+            ];
+        }
+
         if (!$ruleConditions->passes(null, $messageTemplate->conditions)) {
             return [
                 'field' => 'conditions',

--- a/app/Http/Controllers/API/MessageTemplatesController.php
+++ b/app/Http/Controllers/API/MessageTemplatesController.php
@@ -129,12 +129,6 @@ class MessageTemplatesController extends Controller
             ];
         }
 
-        if (!$messageTemplate->outgoing_intent_id) {
-            return [
-                'message' => 'Outgoing Intent ID is required.',
-            ];
-        }
-
         if (!$ruleConditions->passes(null, $messageTemplate->conditions)) {
             return [
                 'field' => 'conditions',

--- a/database/factories/MessageTemplateFactory.php
+++ b/database/factories/MessageTemplateFactory.php
@@ -17,7 +17,7 @@ use Faker\Generator as Faker;
 
 $factory->define(MessageTemplate::class, function (Faker $faker) {
     return [
-        'name' => $faker->name,
+        'name' => $faker->unique()->name,
         'conditions' => '',
         'message_markup' => '<message><text-message>Test</text-message></message>',
     ];

--- a/resources/js/components/message-template/AddMessageTemplate.vue
+++ b/resources/js/components/message-template/AddMessageTemplate.vue
@@ -71,6 +71,7 @@ export default {
         name: this.name,
         conditions: this.conditions,
         message_markup: this.message_markup,
+        outgoing_intent_id: this.outgoingIntent,
       };
 
       axios.post('/admin/api/outgoing-intents/' + this.outgoingIntent + '/message-templates', data).then(

--- a/resources/js/components/message-template/AddMessageTemplate.vue
+++ b/resources/js/components/message-template/AddMessageTemplate.vue
@@ -71,7 +71,6 @@ export default {
         name: this.name,
         conditions: this.conditions,
         message_markup: this.message_markup,
-        outgoing_intent_id: this.outgoingIntent,
       };
 
       axios.post('/admin/api/outgoing-intents/' + this.outgoingIntent + '/message-templates', data).then(

--- a/tests/Feature/MessageTemplatesTest.php
+++ b/tests/Feature/MessageTemplatesTest.php
@@ -102,7 +102,6 @@ class MessageTemplatesTest extends TestCase
                 'name' => 'test',
                 'conditions' => "conditions:\n- condition:\n    attribute: user.name\n    operation: eq\n    value: test",
                 'message_markup' => '<message><text-message>Test</text-message></message>',
-                'outgoing_intent_id' => $outgoingIntent->id,
             ])
             ->assertStatus(201)
             ->assertJsonFragment(
@@ -110,7 +109,7 @@ class MessageTemplatesTest extends TestCase
                     'name' => 'test',
                     'conditions' => "conditions:\n- condition:\n    attribute: user.name\n    operation: eq\n    value: test",
                     'message_markup' => '<message><text-message>Test</text-message></message>',
-                    'outgoing_intent_id' => $outgoingIntent->id,
+                    'outgoing_intent_id' => (string) $outgoingIntent->id,
                 ]
             );
     }


### PR DESCRIPTION
This PR updates the MessageTemplateController's store endpoint. It collects the Outgoing Intent ID from the route parameter and also adds check for the ID to ensure that the Outgoing Intent exists. It also updates the MessageTemplateFactory to ensure that a unique name is generated to satisfy database constraints.

Fixes #41.