### PR TITLE
Corrects AddOutgoingIntent logic

### DIFF
--- a/resources/js/components/outgoing-intent/AddOutgoingIntent.vue
+++ b/resources/js/components/outgoing-intent/AddOutgoingIntent.vue
@@ -40,7 +40,7 @@ export default {
 
       axios.post('/admin/api/outgoing-intents', data).then(
         (response) => {
-          this.$router.push({ name: 'view-message-template', params: { id: response.data.data.id } });
+          this.$router.push({ name: 'view-outgoing-intent', params: { id: response.data.data.id } });
         },
       ).catch(
         (error) => {


### PR DESCRIPTION
This PR fixes #46 by correcting the addOutgoingIntent method of the AddOutgoingIntent Vue component. Previously the method was asking the router to load the MessageTemplate component, when it should have been requesting the OutgoingIntent component. This caused the issue described in #46, as the wrong component was requested and the ID being passed to MessageTemplate was in fact an OutgoingIntent ID.