### PR TITLE
sets a default db port for lando

### DIFF
--- a/.lando.yml.example
+++ b/.lando.yml.example
@@ -15,6 +15,8 @@ proxy:
 services:
   node:
     type: node
+  database:
+    portforward: 3307
   dgraph-zero:
     type: compose
     services:


### PR DESCRIPTION
Sets a standard port for the DB lando creates to 3307. This prevents docker from randomly assigning a port at start.

If you have already started a lando instance for the project, you will need to rebuild with `lando rebuild --yes`

