### PR TITLE
Better Conversation Handling between App and Dgraph backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /public/hot
 /public/storage
 /storage/*.key
+/storage/statuses
 /vendor
 .env
 .phpunit.result.cache

--- a/app/Console/Commands/SetUpConversations.php
+++ b/app/Console/Commands/SetUpConversations.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;
 use OpenDialogAi\ConversationBuilder\Conversation;
+use OpenDialogAi\Core\Conversation\Conversation as ConversationNode;
 use OpenDialogAi\Core\Graph\DGraph\DGraphClient;
 
 class SetUpConversations extends Command
@@ -31,9 +32,9 @@ class SetUpConversations extends Command
         $this->info('Init Schema');
         $client->initSchema();
 
-        $this->info('Setting all existing conversations to unpublished');
+        $this->info('Setting all existing conversations to activatable');
         Conversation::all()->each(function (Conversation $conversation) {
-            $conversation->status = 'validated';
+            $conversation->status = ConversationNode::SAVED;
             $conversation->save();
         });
 
@@ -51,7 +52,7 @@ class SetUpConversations extends Command
             'conversation:import',
             [
                 'filename' => "resources/conversations/$conversationName",
-                '--publish' => true,
+                '--activate' => true,
                 '--yes' => true
             ]
         );

--- a/app/Http/Controllers/API/ConversationRestorationException.php
+++ b/app/Http/Controllers/API/ConversationRestorationException.php
@@ -1,0 +1,11 @@
+<?php
+
+
+namespace App\Http\Controllers\API;
+
+
+use Exception;
+
+class ConversationRestorationException extends Exception
+{
+}

--- a/app/Http/Controllers/API/ConversationsController.php
+++ b/app/Http/Controllers/API/ConversationsController.php
@@ -172,10 +172,10 @@ class ConversationsController extends Controller
         return response()->noContent(404);
     }
 
-    public function publish($id)
+    public function activate($id)
     {
         if ($conversation = Conversation::find($id)) {
-            $ret = $conversation->publishConversation($conversation->buildConversation());
+            $ret = $conversation->activateConversation($conversation->buildConversation());
 
             return response()->json($ret);
         }
@@ -183,10 +183,10 @@ class ConversationsController extends Controller
         return response()->json(false);
     }
 
-    public function unpublish($id)
+    public function deactivate($id)
     {
         if ($conversation = Conversation::find($id)) {
-            $ret = $conversation->unPublishConversation();
+            $ret = $conversation->deactivateConversation();
 
             return response()->json($ret);
         }
@@ -213,9 +213,9 @@ class ConversationsController extends Controller
 
         // Deactivate current version if activated
         if ($conversation->status == ConversationNode::ACTIVATED) {
-            $unpublishResult = $conversation->unPublishConversation();
+            $deactivateResult = $conversation->deactivateConversation();
 
-            if (!$unpublishResult) {
+            if (!$deactivateResult) {
                 return response()->noContent(500);
             }
         }
@@ -248,9 +248,9 @@ class ConversationsController extends Controller
 
         // Deactivate current version if activated
         if ($conversation->status == ConversationNode::ACTIVATED) {
-            $unpublishResult = $conversation->unPublishConversation();
+            $deactivateResult = $conversation->deactivateConversation();
 
-            if (!$unpublishResult) {
+            if (!$deactivateResult) {
                 return response()->noContent(500);
             }
         }
@@ -262,7 +262,7 @@ class ConversationsController extends Controller
 
         // There's no reason for the previous version to not be valid, but just in case of any future changes we check
         if ($conversation->status == ConversationNode::ACTIVATABLE) {
-            $conversation->publishConversation($conversation->buildConversation());
+            $conversation->activateConversation($conversation->buildConversation());
         }
 
         return response()->noContent(200);

--- a/app/Http/Controllers/API/ConversationsController.php
+++ b/app/Http/Controllers/API/ConversationsController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers\API;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\ConversationCollection;
 use App\Http\Resources\ConversationResource;
-use Exception;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Log;
@@ -168,6 +168,7 @@ class ConversationsController extends Controller
      * @param int $id
      * @param int $versionId
      * @return ConversationResource
+     * @throws BindingResolutionException
      */
     public function restore(int $id, int $versionId)
     {
@@ -176,7 +177,7 @@ class ConversationsController extends Controller
 
         try {
             $this->restoreConversation($conversation, $id, $versionId);
-        } catch (Exception $e) {
+        } catch (ConversationRestorationException $e) {
             Log::error($e->getMessage());
             return response()->noContent(500);
         }
@@ -189,7 +190,7 @@ class ConversationsController extends Controller
      * @param int $id
      * @param int $versionId
      * @return ConversationResource
-     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws BindingResolutionException
      */
     public function reactivate(int $id, int $versionId)
     {
@@ -198,7 +199,7 @@ class ConversationsController extends Controller
 
         try {
             $this->restoreConversation($conversation, $id, $versionId);
-        } catch (Exception $e) {
+        } catch (ConversationRestorationException $e) {
             Log::error($e->getMessage());
             return response()->noContent(500);
         }
@@ -263,7 +264,8 @@ class ConversationsController extends Controller
      * @param Conversation $conversation
      * @param int $id
      * @param int $versionId
-     * @throws Exception
+     * @throws ConversationRestorationException
+     * @throws BindingResolutionException
      */
     private function restoreConversation(Conversation $conversation, int $id, int $versionId)
     {
@@ -274,7 +276,7 @@ class ConversationsController extends Controller
         ])->first();
 
         if (is_null($version)) {
-            throw new Exception("Could not find a previous version for restoration.");
+            throw new ConversationRestorationException("Could not find a previous version for restoration.");
         }
 
         // Deactivate current version if activated
@@ -282,7 +284,7 @@ class ConversationsController extends Controller
             $deactivateResult = $conversation->deactivateConversation();
 
             if (!$deactivateResult) {
-                throw new Exception("Tried to deactivate the current version during a restoration but failed.");
+                throw new ConversationRestorationException("Tried to deactivate the current version during a restoration but failed.");
             }
         }
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "fideloper/proxy": "^4.2",
         "laravel/framework": "^6.0",
         "laravel/tinker": "^1.0",
-        "opendialogai/core": "dev-feature/conversation-improvements",
+        "opendialogai/core": "dev-develop",
         "opendialogai/webchat": "dev-develop",
         "phalcongelist/php-diff": "^2.0",
         "propaganistas/laravel-phone": "^4.2",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "fideloper/proxy": "^4.2",
         "laravel/framework": "^6.0",
         "laravel/tinker": "^1.0",
-        "opendialogai/core": "dev-develop",
+        "opendialogai/core": "dev-feature/conversation-improvements",
         "opendialogai/webchat": "dev-develop",
         "phalcongelist/php-diff": "^2.0",
         "propaganistas/laravel-phone": "^4.2",
@@ -73,5 +73,11 @@
             "@php artisan vendor:publish --tag=scripts --force",
             "@php artisan vendor:publish --tag=dgraph --force"
         ]
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/opendialogai/core.git"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -73,11 +73,5 @@
             "@php artisan vendor:publish --tag=scripts --force",
             "@php artisan vendor:publish --tag=dgraph --force"
         ]
-    },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/opendialogai/core.git"
-        }
-    ]
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1843,12 +1843,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "2da3df10d34fc661ad286a51bba7c66bddb9217d"
+                "reference": "b511966d43f71447786a7de926c5250d461b2562"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/2da3df10d34fc661ad286a51bba7c66bddb9217d",
-                "reference": "2da3df10d34fc661ad286a51bba7c66bddb9217d",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/b511966d43f71447786a7de926c5250d461b2562",
+                "reference": "b511966d43f71447786a7de926c5250d461b2562",
                 "shasum": ""
             },
             "require": {
@@ -1934,7 +1934,7 @@
                 "source": "https://github.com/opendialogai/core/tree/feature/conversation-improvements",
                 "issues": "https://github.com/opendialogai/core/issues"
             },
-            "time": "2019-10-15T12:45:23+00:00"
+            "time": "2019-10-15T14:20:42+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/composer.lock
+++ b/composer.lock
@@ -1843,12 +1843,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "b511966d43f71447786a7de926c5250d461b2562"
+                "reference": "9958faca73bc42d06e90b9ccd104e8a0170e3b10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/b511966d43f71447786a7de926c5250d461b2562",
-                "reference": "b511966d43f71447786a7de926c5250d461b2562",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/9958faca73bc42d06e90b9ccd104e8a0170e3b10",
+                "reference": "9958faca73bc42d06e90b9ccd104e8a0170e3b10",
                 "shasum": ""
             },
             "require": {
@@ -1934,7 +1934,7 @@
                 "source": "https://github.com/opendialogai/core/tree/feature/conversation-improvements",
                 "issues": "https://github.com/opendialogai/core/issues"
             },
-            "time": "2019-10-15T14:20:42+00:00"
+            "time": "2019-10-23T09:41:39+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b26e6b7ec49f10b10a3d00cbe984117c",
+    "content-hash": "16bfe663f8917140933f3b1cb6481abe",
     "packages": [
         {
             "name": "anahkiasen/underscore-php",
@@ -1839,16 +1839,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "dev-feature/conversation-improvements",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "9958faca73bc42d06e90b9ccd104e8a0170e3b10"
+                "reference": "6f82c8acd8300f4bcd231c5bc1323d2313c5547b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/9958faca73bc42d06e90b9ccd104e8a0170e3b10",
-                "reference": "9958faca73bc42d06e90b9ccd104e8a0170e3b10",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/6f82c8acd8300f4bcd231c5bc1323d2313c5547b",
+                "reference": "6f82c8acd8300f4bcd231c5bc1323d2313c5547b",
                 "shasum": ""
             },
             "require": {
@@ -1931,10 +1931,10 @@
             ],
             "description": "The OpenDialog core package",
             "support": {
-                "source": "https://github.com/opendialogai/core/tree/feature/conversation-improvements",
+                "source": "https://github.com/opendialogai/core/tree/develop",
                 "issues": "https://github.com/opendialogai/core/issues"
             },
-            "time": "2019-10-23T09:41:39+00:00"
+            "time": "2019-10-25T16:44:55+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/composer.lock
+++ b/composer.lock
@@ -1843,12 +1843,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "bae010558084074dda16156cdc0f45b651ddc603"
+                "reference": "2da3df10d34fc661ad286a51bba7c66bddb9217d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/bae010558084074dda16156cdc0f45b651ddc603",
-                "reference": "bae010558084074dda16156cdc0f45b651ddc603",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/2da3df10d34fc661ad286a51bba7c66bddb9217d",
+                "reference": "2da3df10d34fc661ad286a51bba7c66bddb9217d",
                 "shasum": ""
             },
             "require": {
@@ -1869,7 +1869,7 @@
                 "mockery/mockery": "^1.2",
                 "orchestra/testbench": "^4.0",
                 "phpro/grumphp": "^0.16.0",
-                "phpunit/phpunit": "^8.3",
+                "phpunit/phpunit": "8.3.5",
                 "squizlabs/php_codesniffer": "^3.4"
             },
             "type": "library",
@@ -1882,6 +1882,7 @@
                         "OpenDialogAi\\ConversationLog\\ConversationLogServiceProvider",
                         "OpenDialogAi\\ResponseEngine\\ResponseEngineServiceProvider",
                         "OpenDialogAi\\InterpreterEngine\\InterpreterEngineServiceProvider",
+                        "OpenDialogAi\\OperationEngine\\OperationEngineServiceProvider",
                         "OpenDialogAi\\ContextEngine\\ContextEngineServiceProvider",
                         "OpenDialogAi\\ActionEngine\\ActionEngineServiceProvider",
                         "OpenDialogAi\\SensorEngine\\SensorEngineServiceProvider"
@@ -1901,18 +1902,18 @@
                     "OpenDialogAi\\ConversationLog\\": "src/ConversationLog",
                     "OpenDialogAi\\ResponseEngine\\": "src/ResponseEngine",
                     "OpenDialogAi\\InterpreterEngine\\": "src/InterpreterEngine",
+                    "OpenDialogAi\\OperationEngine\\": "src/OperationEngine",
                     "OpenDialogAi\\SensorEngine\\": "src/SensorEngine",
-                    "OpenDialogAi\\Core\\Database\\": "database/"
-                }
-            },
-            "autoload-dev": {
-                "psr-4": {
+                    "OpenDialogAi\\Core\\Database\\": "database/",
                     "OpenDialogAi\\Core\\Tests\\": "tests/"
                 }
             },
             "scripts": {
                 "test": [
                     "./vendor/bin/phpunit"
+                ],
+                "cs": [
+                    "./vendor/bin/phpcbf --standard=PSR12 --report=full src/"
                 ]
             },
             "license": [
@@ -1933,7 +1934,7 @@
                 "source": "https://github.com/opendialogai/core/tree/feature/conversation-improvements",
                 "issues": "https://github.com/opendialogai/core/issues"
             },
-            "time": "2019-10-03T13:55:46+00:00"
+            "time": "2019-10-15T12:45:23+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cd3ad6042a534430c1620c0603d06edd",
+    "content-hash": "b26e6b7ec49f10b10a3d00cbe984117c",
     "packages": [
         {
             "name": "anahkiasen/underscore-php",
@@ -1839,16 +1839,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "dev-develop",
+            "version": "dev-feature/conversation-improvements",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "e62e96962a9637f482274096d15cbdfc60a9bd95"
+                "reference": "bae010558084074dda16156cdc0f45b651ddc603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/e62e96962a9637f482274096d15cbdfc60a9bd95",
-                "reference": "e62e96962a9637f482274096d15cbdfc60a9bd95",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/bae010558084074dda16156cdc0f45b651ddc603",
+                "reference": "bae010558084074dda16156cdc0f45b651ddc603",
                 "shasum": ""
             },
             "require": {
@@ -1905,7 +1905,16 @@
                     "OpenDialogAi\\Core\\Database\\": "database/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "OpenDialogAi\\Core\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "./vendor/bin/phpunit"
+                ]
+            },
             "license": [
                 "Apache-2.0"
             ],
@@ -1920,7 +1929,11 @@
                 }
             ],
             "description": "The OpenDialog core package",
-            "time": "2019-09-11T08:51:10+00:00"
+            "support": {
+                "source": "https://github.com/opendialogai/core/tree/feature/conversation-improvements",
+                "issues": "https://github.com/opendialogai/core/issues"
+            },
+            "time": "2019-10-03T13:55:46+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",
@@ -4954,8 +4967,8 @@
             "authors": [
                 {
                     "name": "Filipe Dobreira",
-                    "role": "Developer",
-                    "homepage": "https://github.com/filp"
+                    "homepage": "https://github.com/filp",
+                    "role": "Developer"
                 }
             ],
             "description": "php error handling for cool kids",

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -23007,3 +23007,7 @@ body {
   border-radius: 0;
 }
 
+.actions .disabled {
+  cursor: not-allowed;
+}
+

--- a/resources/js/components/conversation/Conversation.vue
+++ b/resources/js/components/conversation/Conversation.vue
@@ -26,13 +26,13 @@
           </template>
 
           <template v-if="conversation.status == 'activated'">
-              <b-btn variant="primary" @click="publishConversation" disabled>Activate</b-btn>
-              <b-btn variant="primary" @click="unpublishConversation">Deactivate</b-btn>
+              <b-btn variant="primary" @click="activateConversation" disabled>Activate</b-btn>
+              <b-btn variant="primary" @click="deactivateConversation">Deactivate</b-btn>
           </template>
           <template v-else-if="['activatable', 'deactivated'].includes(conversation.status)">
               <b-btn v-if="conversation.status == 'deactivated'" variant="danger mr-4" @click="showArchiveConversationModal">Archive</b-btn>
-              <b-btn variant="primary" @click="publishConversation">Activate</b-btn>
-              <b-btn variant="primary" @click="unpublishConversation" disabled>Deactivate</b-btn>
+              <b-btn variant="primary" @click="activateConversation">Activate</b-btn>
+              <b-btn variant="primary" @click="deactivateConversation" disabled>Deactivate</b-btn>
           </template>
         </div>
       </div>
@@ -218,10 +218,10 @@
 </template>
 
 <script>
-import Prism from 'vue-prismjs';
-import 'prismjs/themes/prism.css';
+  import Prism from 'vue-prismjs';
+  import 'prismjs/themes/prism.css';
 
-const moment = require('moment');
+  const moment = require('moment');
 
 export default {
   name: 'conversation',
@@ -315,11 +315,11 @@ export default {
         }
       ).catch(() => this.errorMessage = 'Sorry, I wasn\'t able to restore this conversation version.');
     },
-    publishConversation() {
+    activateConversation() {
       this.errorMessage = '';
       this.successMessage = '';
 
-      axios.get('/admin/api/conversation/' + this.conversation.id + '/publish').then(
+      axios.get('/admin/api/conversation/' + this.conversation.id + '/activate').then(
         (response) => {
           if (response.data) {
             this.successMessage = 'Conversation activated.';
@@ -332,11 +332,11 @@ export default {
         },
       );
     },
-    unpublishConversation() {
+    deactivateConversation() {
       this.errorMessage = '';
       this.successMessage = '';
 
-      axios.get('/admin/api/conversation/' + this.conversation.id + '/unpublish').then(
+      axios.get('/admin/api/conversation/' + this.conversation.id + '/deactivate').then(
         (response) => {
           if (response.data) {
             this.successMessage = 'Conversation deactivated.';
@@ -363,7 +363,7 @@ export default {
       this.errorMessage = '';
       this.successMessage = '';
 
-      axios.get('/admin/api/conversation/' + this.conversation.id + '/unpublish').then(
+      axios.get('/admin/api/conversation/' + this.conversation.id + '/deactivate').then(
         (response) => {
           if (response.data) {
             this.successMessage = 'Conversation unarchived.';

--- a/resources/js/components/conversation/Conversation.vue
+++ b/resources/js/components/conversation/Conversation.vue
@@ -129,7 +129,8 @@
             </button>
           </div>
           <div class="modal-body">
-            <p>Are you sure you want to delete this conversation?</p>
+              <p v-if="conversation.has_been_used">This conversation has already been used, are you sure you want to delete it rather than keeping it in the archive?</p>
+              <p v-else>Are you sure you want to delete this conversation?</p>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-secondary" data-dismiss="modal">No</button>

--- a/resources/js/components/conversation/Conversation.vue
+++ b/resources/js/components/conversation/Conversation.vue
@@ -22,13 +22,13 @@
           <b-btn variant="primary" @click="editConversation">Edit</b-btn>
           <b-btn variant="danger mr-4" @click="showDeleteConversationModal">Delete</b-btn>
 
-          <template v-if="conversation.status == 'published'">
-            <b-btn variant="primary" @click="publishConversation" disabled>Publish</b-btn>
-            <b-btn variant="primary" @click="unpublishConversation">Unpublish</b-btn>
+          <template v-if="conversation.status == 'activated'">
+            <b-btn variant="primary" @click="publishConversation" disabled>Activate</b-btn>
+            <b-btn variant="primary" @click="unpublishConversation">Deactivate</b-btn>
           </template>
           <template v-else>
-            <b-btn variant="primary" @click="publishConversation">Publish</b-btn>
-            <b-btn variant="primary" @click="unpublishConversation" disabled>Unpublish</b-btn>
+            <b-btn variant="primary" @click="publishConversation">Activate</b-btn>
+            <b-btn variant="primary" @click="unpublishConversation" disabled>Deactivate</b-btn>
           </template>
         </div>
       </div>
@@ -90,6 +90,18 @@
     <b-card header="Notes">
       <b-form-textarea :value="conversation.notes" disabled />
     </b-card>
+      <b-card header="History">
+          <b-row class="border-bottom mb-2 pb-2">
+              <b-col class="font-weight-bold" cols="1">Version</b-col>
+              <b-col class="font-weight-bold" cols="1">Status</b-col>
+              <b-col class="font-weight-bold" cols="1">Actions</b-col>
+          </b-row>
+          <b-row v-for="(history_item, index) in conversation.history" class="border-bottom mb-2 pb-2">
+              <b-col cols="1">{{history_item.version_number}}</b-col>
+              <b-col cols="1">{{history_item.status}}</b-col>
+              <b-col cols="1">...</b-col>
+          </b-row>
+      </b-card>
 
     <div class="modal modal-danger fade" id="deleteConversationModal" role="dialog" aria-hidden="true">
       <div class="modal-dialog" role="document">
@@ -168,10 +180,11 @@ export default {
       axios.get('/admin/api/conversation/' + this.conversation.id + '/publish').then(
         (response) => {
           if (response.data) {
-            this.successMessage = 'Conversation published.';
-            this.conversation.status = 'published';
+            this.successMessage = 'Conversation activated.';
+            this.conversation.status = 'activated';
+            this.conversation.version_number++;
           } else {
-            this.errorMessage = 'Sorry, I wasn\'t able to publish this conversation to DGraph.';
+            this.errorMessage = 'Sorry, I wasn\'t able to activate this conversation to DGraph.';
           }
         },
       );
@@ -183,10 +196,10 @@ export default {
       axios.get('/admin/api/conversation/' + this.conversation.id + '/unpublish').then(
         (response) => {
           if (response.data) {
-            this.successMessage = 'Conversation unpublished.';
-            this.conversation.status = 'validated';
+            this.successMessage = 'Conversation deactivated.';
+            this.conversation.status = 'deactivated';
           } else {
-            this.errorMessage = 'Sorry, I wasn\'t able to unpublish this conversation from DGraph.';
+            this.errorMessage = 'Sorry, I wasn\'t able to deactivate this conversation from DGraph.';
           }
         },
       );

--- a/resources/js/components/conversation/Conversation.vue
+++ b/resources/js/components/conversation/Conversation.vue
@@ -19,16 +19,20 @@
     <div class="row mb-4">
       <div class="col-12">
         <div class="float-right">
-          <b-btn variant="primary" @click="editConversation">Edit</b-btn>
-          <b-btn variant="danger mr-4" @click="showDeleteConversationModal">Delete</b-btn>
+          <b-btn v-if="conversation.status != 'archived'" variant="primary mr-4" @click="editConversation">Edit</b-btn>
+          <template v-else>
+              <b-btn variant="danger mr-4" @click="showDeleteConversationModal">Delete</b-btn>
+              <b-btn variant="primary" @click="unarchiveConversation">Unarchive</b-btn>
+          </template>
 
           <template v-if="conversation.status == 'activated'">
-            <b-btn variant="primary" @click="publishConversation" disabled>Activate</b-btn>
-            <b-btn variant="primary" @click="unpublishConversation">Deactivate</b-btn>
+              <b-btn variant="primary" @click="publishConversation" disabled>Activate</b-btn>
+              <b-btn variant="primary" @click="unpublishConversation">Deactivate</b-btn>
           </template>
-          <template v-else>
-            <b-btn variant="primary" @click="publishConversation">Activate</b-btn>
-            <b-btn variant="primary" @click="unpublishConversation" disabled>Deactivate</b-btn>
+          <template v-else-if="['activatable', 'deactivated'].includes(conversation.status)">
+              <b-btn v-if="conversation.status == 'deactivated'" variant="danger mr-4" @click="showArchiveConversationModal">Archive</b-btn>
+              <b-btn variant="primary" @click="publishConversation">Activate</b-btn>
+              <b-btn variant="primary" @click="unpublishConversation" disabled>Deactivate</b-btn>
           </template>
         </div>
       </div>
@@ -90,18 +94,30 @@
     <b-card header="Notes">
       <b-form-textarea :value="conversation.notes" disabled />
     </b-card>
-      <b-card header="History">
-          <b-row class="border-bottom mb-2 pb-2">
-              <b-col class="font-weight-bold" cols="1">Version</b-col>
-              <b-col class="font-weight-bold" cols="1">Status</b-col>
-              <b-col class="font-weight-bold" cols="1">Actions</b-col>
-          </b-row>
-          <b-row v-for="(history_item, index) in conversation.history" class="border-bottom mb-2 pb-2">
-              <b-col cols="1">{{history_item.version_number}}</b-col>
-              <b-col cols="1">{{history_item.status}}</b-col>
-              <b-col cols="1">...</b-col>
-          </b-row>
-      </b-card>
+    <b-card header="History">
+      <b-row class="border-bottom mb-2 pb-2">
+          <b-col class="font-weight-bold" cols="1">Version</b-col>
+          <b-col class="font-weight-bold" cols="2">Date</b-col>
+          <b-col class="font-weight-bold" cols="1">Actions</b-col>
+      </b-row>
+      <b-row v-for="history_item in conversation.history" v-bind:key="history_item.id" class="border-bottom mb-2 pb-2">
+          <b-col cols="1">{{ history_item.attributes.version_number }}</b-col>
+          <b-col cols="2">{{ history_item.timestamp | date }}</b-col>
+          <b-col>
+              <button class="btn btn-primary" data-toggle="tooltip" data-placement="top" title="View" @click.stop="showViewConversationModel(history_item.attributes.model)">
+                  <i class="fa fa-eye"></i>
+              </button>
+
+              <button class="btn btn-success" data-toggle="tooltip" data-placement="top" title="Edit" @click.stop="showEditConversationModel(history_item.id)">
+                  <i class="fa fa-edit"></i>
+              </button>
+
+              <button class="btn btn-primary ml-2" data-toggle="tooltip" data-placement="top" title="Activate" @click.stop="showActivateConversationModel(history_item.id)">
+                  <i class="fa fa-upload"></i>
+              </button>
+          </b-col>
+      </b-row>
+    </b-card>
 
     <div class="modal modal-danger fade" id="deleteConversationModal" role="dialog" aria-hidden="true">
       <div class="modal-dialog" role="document">
@@ -122,12 +138,90 @@
         </div>
       </div>
     </div>
+
+    <div class="modal modal-danger fade" id="archiveConversationModal" role="dialog" aria-hidden="true">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Archive Conversation</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <p>Are you sure you want to archive this conversation?</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">No</button>
+                    <button type="button" class="btn btn-danger" @click="archiveConversation">Yes</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="modal modal-primary fade" id="editConversationModal" role="dialog" aria-hidden="true">
+      <div class="modal-dialog" role="document">
+          <div class="modal-content">
+              <div class="modal-header">
+                  <h5 class="modal-title">Restore Previous Conversation Version</h5>
+                  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                      <span aria-hidden="true">&times;</span>
+                  </button>
+              </div>
+              <div class="modal-body">
+                  <p>Are you sure you want to restore this version? The conversation model will be updated and automatically set as deactivated.</p>
+              </div>
+              <div class="modal-footer">
+                  <button type="button" class="btn btn-secondary" data-dismiss="modal">No</button>
+                  <button type="button" class="btn btn-primary" @click="editPreviousVersion">Yes</button>
+              </div>
+          </div>
+      </div>
+    </div>
+
+    <div class="modal modal-primary fade" id="activateConversationModal" role="dialog" aria-hidden="true">
+      <div class="modal-dialog" role="document">
+          <div class="modal-content">
+              <div class="modal-header">
+                  <h5 class="modal-title">Restore Previous Conversation Version</h5>
+                  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                      <span aria-hidden="true">&times;</span>
+                  </button>
+              </div>
+              <div class="modal-body">
+                  <p>Are you sure you want to activate this version?</p>
+              </div>
+              <div class="modal-footer">
+                  <button type="button" class="btn btn-secondary" data-dismiss="modal">No</button>
+                  <button type="button" class="btn btn-primary" @click="activatePreviousVersion">Yes</button>
+              </div>
+          </div>
+      </div>
+    </div>
+
+    <div class="modal modal-primary fade" id="viewConversationModal" role="dialog" aria-hidden="true">
+      <div class="modal-dialog" role="document">
+          <div class="modal-content">
+              <div class="modal-header">
+                  <h5 class="modal-title">Viewing Previous Conversation Version</h5>
+                  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                      <span aria-hidden="true">&times;</span>
+                  </button>
+              </div>
+              <div class="modal-body">
+                  <prism language="yaml" :code="currentHistoryModel"></prism>
+              </div>
+          </div>
+      </div>
+    </div>
   </div>
 </template>
 
 <script>
 import Prism from 'vue-prismjs';
 import 'prismjs/themes/prism.css';
+
+const moment = require('moment');
 
 export default {
   name: 'conversation',
@@ -140,6 +234,8 @@ export default {
       conversation: null,
       errorMessage: '',
       successMessage: '',
+      currentHistoryModel: null,
+      currentHistoryId: null
     };
   },
   watch: {
@@ -149,6 +245,13 @@ export default {
   },
   mounted() {
     this.fetchConversation();
+  },
+  filters: {
+    date: (value) => {
+      if (value) {
+        return moment(value).format('MMMM D, YYYY HH:mm');
+      }
+    },
   },
   methods: {
     fetchConversation() {
@@ -173,6 +276,45 @@ export default {
 
       this.$router.push({ name: 'conversations' });
     },
+    showViewConversationModel(model) {
+      this.currentHistoryModel = model;
+      $('#viewConversationModal').modal();
+    },
+    showEditConversationModel(id) {
+      this.currentHistoryId = id;
+      $('#editConversationModal').modal();
+    },
+    showActivateConversationModel(id) {
+      this.currentHistoryId = id;
+      $('#activateConversationModal').modal();
+    },
+    showArchiveConversationModal() {
+      $('#archiveConversationModal').modal();
+    },
+    activatePreviousVersion() {
+      this.errorMessage = '';
+      this.successMessage = '';
+      $('#activateConversationModal').modal('hide');
+
+      axios.get('/admin/api/conversation/' + this.conversation.id + '/reactivate/' + this.currentHistoryId).then(
+        (response) => {
+            this.successMessage = 'Conversation reactivated.';
+            this.fetchConversation();
+        },
+      ).catch(() => this.errorMessage = 'Sorry, I wasn\'t able to reactivate this conversation version.');
+    },
+    editPreviousVersion() {
+      this.errorMessage = '';
+      this.successMessage = '';
+      $('#editConversationModal').modal('hide');
+
+      axios.get('/admin/api/conversation/' + this.conversation.id + '/restore/' + this.currentHistoryId).then(
+        (response) => {
+            this.successMessage = 'Conversation restored.';
+            this.fetchConversation();
+        }
+      ).catch(() => this.errorMessage = 'Sorry, I wasn\'t able to restore this conversation version.');
+    },
     publishConversation() {
       this.errorMessage = '';
       this.successMessage = '';
@@ -183,6 +325,7 @@ export default {
             this.successMessage = 'Conversation activated.';
             this.conversation.status = 'activated';
             this.conversation.version_number++;
+            this.fetchConversation();
           } else {
             this.errorMessage = 'Sorry, I wasn\'t able to activate this conversation to DGraph.';
           }
@@ -204,6 +347,34 @@ export default {
         },
       );
     },
+    archiveConversation() {
+      this.errorMessage = '';
+      this.successMessage = '';
+      $('#archiveConversationModal').modal('hide');
+
+      axios.get('/admin/api/conversation/' + this.conversation.id + '/archive').then(
+        (response) => {
+          this.successMessage = 'Conversation archived.';
+          this.fetchConversation();
+        },
+      ).catch(() => this.errorMessage = 'Sorry, I wasn\'t able to archive this conversation version.');
+    },
+    unarchiveConversation() {
+      this.errorMessage = '';
+      this.successMessage = '';
+
+      axios.get('/admin/api/conversation/' + this.conversation.id + '/unpublish').then(
+        (response) => {
+          if (response.data) {
+            this.successMessage = 'Conversation unarchived.';
+            this.conversation.status = 'deactivated';
+            this.fetchConversation();
+          } else {
+            this.errorMessage = 'Sorry, I wasn\'t able to unarchive this conversation.';
+          }
+        },
+      );
+    }
   },
 };
 </script>

--- a/resources/js/components/conversation/Conversation.vue
+++ b/resources/js/components/conversation/Conversation.vue
@@ -169,7 +169,7 @@
                   </button>
               </div>
               <div class="modal-body">
-                  <p>Are you sure you want to restore this version? The conversation model will be updated and automatically set as deactivated.</p>
+                  <p>Are you sure you want to restore this version? The conversation model will be updated and automatically set as activatable.</p>
               </div>
               <div class="modal-footer">
                   <button type="button" class="btn btn-secondary" data-dismiss="modal">No</button>

--- a/resources/js/components/conversation/Conversations.vue
+++ b/resources/js/components/conversation/Conversations.vue
@@ -80,18 +80,18 @@
               </button>
 
               <template v-if="conversation.status == 'activated'">
-                <button class="btn btn-primary ml-2" data-toggle="tooltip" data-placement="top" title="Activate" @click.stop="publishConversation(conversation)" disabled>
+                <button class="btn btn-primary ml-2" data-toggle="tooltip" data-placement="top" title="Activate" @click.stop="activateConversation(conversation)" disabled>
                   <i class="fa fa-upload"></i>
                 </button>
-                <button class="btn btn-primary" data-toggle="tooltip" data-placement="top" title="Deactivate" @click.stop="unpublishConversation(conversation)">
+                <button class="btn btn-primary" data-toggle="tooltip" data-placement="top" title="Deactivate" @click.stop="deactivateConversation(conversation)">
                   <i class="fa fa-download"></i>
                 </button>
               </template>
               <template v-else>
-                <button class="btn btn-primary ml-2" data-toggle="tooltip" data-placement="top" title="Activate" @click.stop="publishConversation(conversation)">
+                <button class="btn btn-primary ml-2" data-toggle="tooltip" data-placement="top" title="Activate" @click.stop="activateConversation(conversation)">
                   <i class="fa fa-upload"></i>
                 </button>
-                <button class="btn btn-primary" data-toggle="tooltip" data-placement="top" title="Deactivate" @click.stop="unpublishConversation(conversation)" disabled>
+                <button class="btn btn-primary" data-toggle="tooltip" data-placement="top" title="Deactivate" @click.stop="deactivateConversation(conversation)" disabled>
                   <i class="fa fa-download"></i>
                 </button>
               </template>
@@ -165,9 +165,9 @@
 </template>
 
 <script>
-import Pager from '@/mixins/Pager';
+  import Pager from '@/mixins/Pager';
 
-export default {
+  export default {
   name: 'conversations',
   mixins: [Pager],
   data() {
@@ -209,11 +209,11 @@ export default {
     viewArchive() {
       this.$router.push({ name: 'conversations-archive' });
     },
-    publishConversation(conversation) {
+    activateConversation(conversation) {
       this.errorMessage = '';
       this.successMessage = '';
 
-      axios.get('/admin/api/conversation/' + conversation.id + '/publish').then(
+      axios.get('/admin/api/conversation/' + conversation.id + '/activate').then(
         (response) => {
           if (response.data) {
             this.successMessage = 'Conversation activated.';
@@ -225,11 +225,11 @@ export default {
         },
       );
     },
-    unpublishConversation(conversation) {
+    deactivateConversation(conversation) {
       this.errorMessage = '';
       this.successMessage = '';
 
-      axios.get('/admin/api/conversation/' + conversation.id + '/unpublish').then(
+      axios.get('/admin/api/conversation/' + conversation.id + '/deactivate').then(
         (response) => {
           if (response.data) {
             this.successMessage = 'Conversation deactivated.';

--- a/resources/js/components/conversation/Conversations.vue
+++ b/resources/js/components/conversation/Conversations.vue
@@ -75,12 +75,12 @@
               <button v-if="conversation.status == 'archived'" class="btn btn-danger" data-toggle="tooltip" data-placement="top" title="Delete" @click.stop="showDeleteConversationModal(conversation.id)">
                 <i class="fa fa-close"></i>
               </button>
-              <button v-else class="btn btn-danger" data-toggle="tooltip" data-placement="top" title="Archive" @click.stop="showArchiveConversationModal(conversation.id)" :disabled="conversation.status != 'deactivated'">
+              <button v-else v-bind:class="[conversation.status != 'deactivated' ? 'disabled' : '', 'btn', 'btn-danger']" data-toggle="tooltip" data-placement="top" title="Archive" @click.stop="showArchiveConversationModal(conversation.id)" :disabled="conversation.status != 'deactivated'" :aria-disabled="conversation.status != 'deactivated'">
                 <i class="fa fa-trash"></i>
               </button>
 
               <template v-if="conversation.status == 'activated'">
-                <button class="btn btn-primary ml-2" data-toggle="tooltip" data-placement="top" title="Activate" @click.stop="activateConversation(conversation)" disabled>
+                <button class="btn btn-primary ml-2 disabled" data-toggle="tooltip" data-placement="top" title="Activate" @click.stop="activateConversation(conversation)" disabled aria-disabled>
                   <i class="fa fa-upload"></i>
                 </button>
                 <button class="btn btn-primary" data-toggle="tooltip" data-placement="top" title="Deactivate" @click.stop="deactivateConversation(conversation)">
@@ -91,7 +91,7 @@
                 <button class="btn btn-primary ml-2" data-toggle="tooltip" data-placement="top" title="Activate" @click.stop="activateConversation(conversation)">
                   <i class="fa fa-upload"></i>
                 </button>
-                <button class="btn btn-primary" data-toggle="tooltip" data-placement="top" title="Deactivate" @click.stop="deactivateConversation(conversation)" disabled>
+                <button class="btn btn-primary disabled" data-toggle="tooltip" data-placement="top" title="Deactivate" @click.stop="deactivateConversation(conversation)" disabled aria-disabled>
                   <i class="fa fa-download"></i>
                 </button>
               </template>

--- a/resources/js/components/conversation/Conversations.vue
+++ b/resources/js/components/conversation/Conversations.vue
@@ -39,7 +39,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr v-for="conversation in conversations" @click="viewConversation(conversation.id)">
+          <tr v-for="conversation in conversations">
             <td>
               {{ conversation.id }}
             </td>

--- a/resources/js/components/conversation/ConversationsArchive.vue
+++ b/resources/js/components/conversation/ConversationsArchive.vue
@@ -37,7 +37,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr v-for="conversation in conversations" @click="viewConversation(conversation.id)">
+          <tr v-for="conversation in conversations">
             <td>
               {{ conversation.id }}
             </td>

--- a/resources/js/components/conversation/ConversationsArchive.vue
+++ b/resources/js/components/conversation/ConversationsArchive.vue
@@ -64,7 +64,7 @@
               <button class="btn btn-success" data-toggle="tooltip" data-placement="top" title="Unarchive" @click.stop="unarchiveConversation(conversation.id)">
                   <i class="fa fa-refresh"></i>
               </button>
-              <button class="btn btn-danger" data-toggle="tooltip" data-placement="top" title="Delete" @click.stop="showDeleteConversationModal(conversation.id)">
+              <button class="btn btn-danger" data-toggle="tooltip" data-placement="top" title="Delete" @click.stop="showDeleteConversationModal(conversation)">
                 <i class="fa fa-close"></i>
               </button>
             </td>
@@ -104,7 +104,8 @@
             </button>
           </div>
           <div class="modal-body">
-            <p>Are you sure you want to delete this conversation?</p>
+            <p v-if="currentConversationHasBeenUsed">This conversation has already been used, are you sure you want to delete it rather than keeping it in the archive?</p>
+            <p v-else>Are you sure you want to delete this conversation?</p>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-secondary" data-dismiss="modal">No</button>
@@ -128,6 +129,7 @@
       successMessage: '',
       conversations: [],
       currentConversation: null,
+      currentConversationHasBeenUsed: false
     };
   },
   watch: {
@@ -158,8 +160,9 @@
     viewConversation(id) {
       this.$router.push({ name: 'view-conversation', params: { id } });
     },
-    showDeleteConversationModal(id) {
-      this.currentConversation = id;
+    showDeleteConversationModal(conversation) {
+      this.currentConversation = conversation.id;
+      this.currentConversationHasBeenUsed = conversation.has_been_used; 
       $('#deleteConversationModal').modal();
     },
     deleteConversation() {

--- a/resources/js/components/conversation/ConversationsArchive.vue
+++ b/resources/js/components/conversation/ConversationsArchive.vue
@@ -117,9 +117,9 @@
 </template>
 
 <script>
-import Pager from '@/mixins/Pager';
+  import Pager from '@/mixins/Pager';
 
-export default {
+  export default {
   name: 'conversations-archive',
   mixins: [Pager],
   data() {
@@ -174,7 +174,7 @@ export default {
       this.errorMessage = '';
       this.successMessage = '';
 
-      axios.get('/admin/api/conversation/' + id + '/unpublish').then(
+      axios.get('/admin/api/conversation/' + id + '/deactivate').then(
         (response) => {
           if (response.data) {
             this.successMessage = 'Conversation unarchived.';

--- a/resources/js/router/index.js
+++ b/resources/js/router/index.js
@@ -60,6 +60,11 @@ const router = new VueRouter({
           component: Conversation,
         },
         {
+            path: 'conversations/archive',
+            name: 'conversations-archive',
+            component: Conversation,
+        },
+        {
           path: 'conversations/add',
           name: 'add-conversation',
           component: Conversation,

--- a/resources/js/views/Conversation.vue
+++ b/resources/js/views/Conversation.vue
@@ -9,6 +9,9 @@
     <template v-else-if="currentRouteName == 'add-conversation'">
       <AddConversation />
     </template>
+    <template v-else-if="currentRouteName == 'conversations-archive'">
+        <ConversationArchive />
+    </template>
     <template v-else>
       <Conversations />
     </template>
@@ -20,6 +23,7 @@ import AddConversation from '@/components/conversation/AddConversation';
 import Conversation from '@/components/conversation/Conversation';
 import Conversations from '@/components/conversation/Conversations';
 import EditConversation from '@/components/conversation/EditConversation';
+import ConversationArchive from '@/components/conversation/ConversationsArchive';
 
 export default {
   name: 'conversation',
@@ -29,6 +33,7 @@ export default {
     Conversation,
     Conversations,
     EditConversation,
+    ConversationArchive
   },
   computed: {
     currentRouteName() {

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -43,3 +43,9 @@ $simple-line-font-path: '~simple-line-icons/fonts/';
 .img-avatar {
   border-radius: 0;
 }
+
+.actions {
+    .disabled {
+        cursor: not-allowed;
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -26,10 +26,14 @@ Route::namespace('API')->middleware(['auth:api'])->prefix('admin/api')->group(fu
     Route::apiResource('outgoing-intents', 'OutgoingIntentsController');
     Route::apiResource('outgoing-intents/{id}/message-templates', 'MessageTemplatesController');
 
+    Route::get('conversation-archive', 'ConversationsController@viewArchive');
     Route::prefix('conversation/{id}')->group(function () {
         Route::get('/publish', 'ConversationsController@publish');
         Route::get('/unpublish', 'ConversationsController@unpublish');
         Route::get('/archive', 'ConversationsController@archive');
+
+        Route::get('/restore/{versionId}', 'ConversationsController@restore');
+        Route::get('/reactivate/{versionId}', 'ConversationsController@reactivate');
     });
 
     Route::get('chatbot-user/{id}/messages', 'ChatbotUsersController@messages');

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,6 +29,7 @@ Route::namespace('API')->middleware(['auth:api'])->prefix('admin/api')->group(fu
     Route::prefix('conversation/{id}')->group(function () {
         Route::get('/publish', 'ConversationsController@publish');
         Route::get('/unpublish', 'ConversationsController@unpublish');
+        Route::get('/archive', 'ConversationsController@archive');
     });
 
     Route::get('chatbot-user/{id}/messages', 'ChatbotUsersController@messages');

--- a/routes/api.php
+++ b/routes/api.php
@@ -28,8 +28,8 @@ Route::namespace('API')->middleware(['auth:api'])->prefix('admin/api')->group(fu
 
     Route::get('conversation-archive', 'ConversationsController@viewArchive');
     Route::prefix('conversation/{id}')->group(function () {
-        Route::get('/publish', 'ConversationsController@publish');
-        Route::get('/unpublish', 'ConversationsController@unpublish');
+        Route::get('/activate', 'ConversationsController@activate');
+        Route::get('/deactivate', 'ConversationsController@deactivate');
         Route::get('/archive', 'ConversationsController@archive');
 
         Route::get('/restore/{versionId}', 'ConversationsController@restore');

--- a/tests/Feature/ConversationsTest.php
+++ b/tests/Feature/ConversationsTest.php
@@ -138,8 +138,8 @@ class ConversationsTest extends TestCase
     {
         /** @var Conversation $firstConversation */
         $conversation = Conversation::first();
-        $conversation->publishConversation($conversation->buildConversation());
-        $conversation->unPublishConversation();
+        $conversation->activateConversation($conversation->buildConversation());
+        $conversation->deactivateConversation();
         $conversation->archiveConversation();
 
         $this->actingAs($this->user, 'api')
@@ -149,25 +149,25 @@ class ConversationsTest extends TestCase
         $this->assertEquals(Conversation::find($conversation->id),  null);
     }
 
-    public function testConversationsPublishEndpoint()
+    public function testConversationsActivateEndpoint()
     {
         $conversation = Conversation::first();
 
         $response = $this->actingAs($this->user, 'api')
-            ->json('GET', '/admin/api/conversation/' . $conversation->id . '/publish')
+            ->json('GET', '/admin/api/conversation/' . $conversation->id . '/activate')
             ->assertStatus(200);
 
         $this->assertEquals($response->content(), 'true');
     }
 
-    public function testConversationsUnpublishEndpoint()
+    public function testConversationsDeactivateEndpoint()
     {
         $conversation = Conversation::first();
 
-        $conversation->publishConversation($conversation->buildConversation());
+        $conversation->activateConversation($conversation->buildConversation());
 
         $response = $this->actingAs($this->user, 'api')
-            ->json('GET', '/admin/api/conversation/' . $conversation->id . '/unpublish')
+            ->json('GET', '/admin/api/conversation/' . $conversation->id . '/deactivate')
             ->assertStatus(200);
 
         $this->assertEquals($response->content(), 'true');
@@ -177,10 +177,10 @@ class ConversationsTest extends TestCase
     {
         $conversation = Conversation::first();
 
-        $conversation->publishConversation($conversation->buildConversation());
-        $conversation->unpublishConversation();
+        $conversation->activateConversation($conversation->buildConversation());
+        $conversation->deactivateConversation();
 
-        $response = $this->actingAs($this->user, 'api')
+        $this->actingAs($this->user, 'api')
             ->json('GET', '/admin/api/conversation/' . $conversation->id . '/archive')
             ->assertStatus(200);
     }

--- a/tests/Feature/ConversationsTest.php
+++ b/tests/Feature/ConversationsTest.php
@@ -136,13 +136,17 @@ class ConversationsTest extends TestCase
 
     public function testConversationsDestroyEndpoint()
     {
+        /** @var Conversation $firstConversation */
         $conversation = Conversation::first();
+        $conversation->publishConversation($conversation->buildConversation());
+        $conversation->unPublishConversation();
+        $conversation->archiveConversation();
 
         $this->actingAs($this->user, 'api')
             ->json('DELETE', '/admin/api/conversation/' . $conversation->id)
             ->assertStatus(200);
 
-        $this->assertEquals(Conversation::find($conversation->id), null);
+        $this->assertEquals(Conversation::find($conversation->id),  null);
     }
 
     public function testConversationsPublishEndpoint()
@@ -167,6 +171,18 @@ class ConversationsTest extends TestCase
             ->assertStatus(200);
 
         $this->assertEquals($response->content(), 'true');
+    }
+
+    public function testConversationsArchiveEndpoint()
+    {
+        $conversation = Conversation::first();
+
+        $conversation->publishConversation($conversation->buildConversation());
+        $conversation->unpublishConversation();
+
+        $response = $this->actingAs($this->user, 'api')
+            ->json('GET', '/admin/api/conversation/' . $conversation->id . '/archive')
+            ->assertStatus(200);
     }
 
     public function testConversationsInvalidStoreEndpoint()


### PR DESCRIPTION
This PR is dependent on changes from opendialogai/core#229. Changes included in this PR and https://github.com/opendialogai/core/pull/229 fix #70.

## Changes
### Version history
This PR adds a section to conversation template pages that lists the version history of the template. The version history is retrieved by querying the ActivityLog and filtering by logs where the version number changed. Each previous version can be viewed, restored or reactivated. Restoring a version will bring the version back but not as an activated conversation, whereas reactivating will restore and activate the conversation.

### Archive listing & archiving
To account for the new statuses added in opendialogai/core#229, buttons have been added to the template listing page and template page that allow conversations to be archived. Archived conservations are hidden from the regular listing page and are displayed on the new template archive listing page.