### PR TITLE
resets the conversation version and graph uid when refreshing conversations

### DIFF
--- a/app/Console/Commands/SetUpConversations.php
+++ b/app/Console/Commands/SetUpConversations.php
@@ -34,6 +34,8 @@ class SetUpConversations extends Command
             $this->info('Setting all existing conversations to activatable');
             Conversation::all()->each(function (Conversation $conversation) {
                 $conversation->status = ConversationNode::SAVED;
+                $conversation->version_number = 0;
+                $conversation->graph_uid = null;
                 $conversation->save();
             });
 


### PR DESCRIPTION
Before this fix, running `artisan conversations:setup` with existing conversations in your database would give the following error:

   ErrorException  : Undefined offset: 0


The changes here reset the version number and DGraph uid of each conversation before running the import to avoid this