### PR TITLE
Remove child elements from sidebar

### DIFF
--- a/app/Http/Controllers/API/ConversationsController.php
+++ b/app/Http/Controllers/API/ConversationsController.php
@@ -246,26 +246,6 @@ class ConversationsController extends Controller
 
 
     /**
-     * Returns a list of conversations that can be used in a menu system
-     *
-     * @return array
-     */
-    public function adminList(): array
-    {
-        $conversations = [];
-
-        foreach (Conversation::all() as $conversation) {
-            $conversations[] = [
-                'name' => $conversation->name,
-                'url' => '/admin/conversations/' . $conversation->id,
-            ];
-        }
-
-        return $conversations;
-    }
-
-
-    /**
      * @param Conversation $conversation
      * @return array
      */

--- a/app/Http/Controllers/API/WebchatSettingsController.php
+++ b/app/Http/Controllers/API/WebchatSettingsController.php
@@ -70,39 +70,6 @@ class WebchatSettingsController extends Controller
 
 
     /**
-     * Returns a list of webchat settings with links that can be used in menus
-     *
-     * @return array
-     */
-    public function getCategories(): array
-    {
-        $generalId = WebchatSetting::where('name', WebchatSetting::GENERAL)->first()->id;
-        $coloursId = WebchatSetting::where('name', WebchatSetting::COLOURS)->first()->id;
-        $commentsId = WebchatSetting::where('name', WebchatSetting::COMMENTS)->first()->id;
-        $historyId = WebchatSetting::where('name', WebchatSetting::WEBCHAT_HISTORY)->first()->id;
-
-        return [
-            [
-                'name' => 'General',
-                'url' => '/admin/webchat-setting/' . $generalId,
-            ],
-            [
-                'name' => 'Colours',
-                'url' => '/admin/webchat-setting/' . $coloursId,
-            ],
-            [
-                'name' => 'Comments',
-                'url' => '/admin/webchat-setting/' . $commentsId,
-            ],
-            [
-                'name' => 'History',
-                'url' => '/admin/webchat-setting/' . $historyId,
-            ],
-        ];
-    }
-
-
-    /**
      * @param WebchatSetting $setting
      * @param string         $newValue
      * @return string

--- a/config/admin-navigation.php
+++ b/config/admin-navigation.php
@@ -22,13 +22,11 @@ return [
             'title' => 'Webchat settings',
             'url' => '/admin/webchat-setting',
             'icon' => 'icon-settings',
-            'children' => '/admin/api/webchat-settings-categories',
         ],
         [
             'title' => 'Conversations',
             'url' => '/admin/conversations',
             'icon' => 'icon-speech',
-            'children' => '/admin/api/conversations-list',
         ],
         [
             'title' => 'Requests',

--- a/routes/api.php
+++ b/routes/api.php
@@ -45,7 +45,4 @@ Route::namespace('API')->middleware(['auth:api'])->prefix('admin/api')->group(fu
 
     Route::get('warnings', 'WarningsController@index');
     Route::get('warnings/{id}', 'WarningsController@show');
-
-    Route::get('conversations-list', 'ConversationsController@adminList');
-    Route::get('webchat-settings-categories', 'WebchatSettingsController@getCategories');
 });


### PR DESCRIPTION
This PR removes the child elements from the sidebar, specifically the conversation and webchat setting items. This allows the parent elements to be clicked/tapped as a regular link to the conversation listing or settings page respectively.