### PR TITLE
Bug: Warning user_id's not null constraint

### DIFF
--- a/app/Logging/LogHandler.php
+++ b/app/Logging/LogHandler.php
@@ -4,6 +4,7 @@ namespace App\Logging;
 
 use App\Warning;
 use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\Log;
 use Monolog\Formatter\FormatterInterface;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Logger;
@@ -23,7 +24,7 @@ class LogHandler extends AbstractProcessingHandler
             try {
                 $log->save();
             } catch (QueryException $e) {
-                //
+                Log::debug(sprintf('Warning was not persisted to the database: %s', $e->getMessage()));
             }
         }
     }

--- a/app/Logging/LogHandler.php
+++ b/app/Logging/LogHandler.php
@@ -3,6 +3,7 @@
 namespace App\Logging;
 
 use App\Warning;
+use Illuminate\Database\QueryException;
 use Monolog\Formatter\FormatterInterface;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Logger;
@@ -19,7 +20,11 @@ class LogHandler extends AbstractProcessingHandler
         if (!empty($record['formatted'])) {
             $log = new Warning();
             $log->fill($record['formatted']);
-            $log->save();
+            try {
+                $log->save();
+            } catch (QueryException $e) {
+                //
+            }
         }
     }
 

--- a/database/migrations/2020_01_30_154154_update_warnings_user_id.php
+++ b/database/migrations/2020_01_30_154154_update_warnings_user_id.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateWarningsUserId extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('warnings', function (Blueprint $table) {
+            $table->string('user_id')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('warnings', function (Blueprint $table) {
+            $table->string('user_id');
+        });
+    }
+}


### PR DESCRIPTION
This PR fixes a bug in which if you try to Log a warning without a related User ID the system fails. An uncaught exception was thrown from the LogHandler due to a database constraint that the Warning's `user_id` field not be null. This PR catches any such exceptions and also makes `user_id` nullable.