### PR TITLE
initial error handling for XML validation

### DIFF
--- a/resources/js/components/message-template/AddMessageTemplate.vue
+++ b/resources/js/components/message-template/AddMessageTemplate.vue
@@ -26,7 +26,7 @@
       </b-form-group>
 
       <b-card>
-        <MessageBuilder v-if="previewData" :message="previewData" v-model="previewData"/>
+        <MessageBuilder v-if="previewData" :message="previewData" v-model="previewData" v-on:errorEmit="errorEmitCatcher"/>
       </b-card>
 
       <b-btn variant="primary" @click="addMessageTemplate">Create</b-btn>
@@ -100,6 +100,12 @@ export default {
         },
       );
     },
+    errorEmitCatcher(error) {
+      this.error = {};
+      if (error) {
+        this.error.field = 'message_markup';
+      }
+    }
   },
 };
 </script>

--- a/resources/js/components/message-template/EditMessageTemplate.vue
+++ b/resources/js/components/message-template/EditMessageTemplate.vue
@@ -22,11 +22,11 @@
 
       <b-form-group>
         <label>Message Mark-up</label>
-        <codemirror v-model="messageTemplate.message_markup" :options="cmMarkupOptions" :class="(error.field == 'message_markup') ? 'is-invalid' : ''" />
+        <codemirror v-model="messageTemplate.message_markup" :options="cmMarkupOptions" :class="(error.field == 'message_markup') ? 'is-invalid' : ''"/>
       </b-form-group>
 
       <b-card>
-         <MessageBuilder v-if="previewData" :message="previewData" v-model="previewData"/>
+         <MessageBuilder v-if="previewData" :message="previewData" v-model="previewData" v-on:errorEmit="errorEmitCatcher"/>
       </b-card>
 
       <b-btn variant="primary" @click="saveMessageTemplate">Save</b-btn>
@@ -99,6 +99,12 @@ export default {
         },
       );
     },
+    errorEmitCatcher(error) {
+      this.error = {};
+      if (error) {
+        this.error.field = 'message_markup';
+      }
+    }
   },
 };
 </script>

--- a/resources/js/components/message-template/MessageBuilder.vue
+++ b/resources/js/components/message-template/MessageBuilder.vue
@@ -115,6 +115,7 @@ export default {
             const doc = parser.parseFromString(val.message_markup, 'application/xml');
             if (doc.getElementsByTagName('parsererror').length > 0) {
                 const error = doc.getElementsByTagName('parsererror')[0].getElementsByTagName('div')[0].innerHTML;
+                this.$emit('errorEmit', error);
                 this.messages.push(
                     {
                         type: 'error',
@@ -122,6 +123,7 @@ export default {
                     }
                 );
             } else {
+                this.$emit('errorEmit', '');
                 const document = new xmldoc.XmlDocument(val.message_markup);
                 this.parseDocumentForMessage(document)
             }

--- a/resources/js/components/message-template/Messages/Error.vue
+++ b/resources/js/components/message-template/Messages/Error.vue
@@ -1,0 +1,10 @@
+<template>
+  <div class="error" v-html="message.data"></div>
+</template>
+
+<script>
+export default {
+  name: 'error',
+  props: ['message'],
+};
+</script>


### PR DESCRIPTION
Gives the user early site of XML validation errors
We may want this a bit more user friendly:
![image](https://user-images.githubusercontent.com/1316576/85029068-cdc7cc00-b173-11ea-9dd3-5d6f03b8945e.png)
