### PR TITLE
conditions ui

### DIFF
--- a/resources/js/components/message-template/AddMessageTemplate.vue
+++ b/resources/js/components/message-template/AddMessageTemplate.vue
@@ -17,7 +17,7 @@
 
       <b-form-group>
         <label>Conditions</label>
-        <codemirror v-model="conditions" :options="cmConditionsOptions" :class="(error.field == 'conditions') ? 'is-invalid' : ''" />
+        <codemirror v-model="conditions" :options="cmConditionsOptions" :class="(error.field == 'conditions') ? 'is-invalid' : ''" class="collapse-codemirror"/>
       </b-form-group>
 
       <b-card header="Message Builder">
@@ -30,7 +30,7 @@
 
       <b-form-group>
         <label>Message Mark-up</label>
-        <codemirror v-model="message_markup" :options="cmMarkupOptions" :class="(error.field == 'message_markup') ? 'is-invalid' : ''" />
+        <codemirror v-model="message_markup" :options="cmMarkupOptions" :class="(error.field == 'message_markup') ? 'is-invalid' : ''" class="collapse-codemirror"/>
       </b-form-group>
 
       <b-card>
@@ -77,7 +77,7 @@ export default {
       },
       name: '',
       conditions: '',
-      message_markup: '<message></message>',
+      message_markup: '<message>\n</message>',
       error: {},
       messageTypes: ''
     };

--- a/resources/js/components/message-template/EditMessageTemplate.vue
+++ b/resources/js/components/message-template/EditMessageTemplate.vue
@@ -17,12 +17,12 @@
 
       <b-form-group>
         <label>Conditions</label>
-        <codemirror v-model="messageTemplate.conditions" :options="cmConditionsOptions" :class="(error.field == 'conditions') ? 'is-invalid' : ''" />
+        <codemirror v-model="messageTemplate.conditions" :options="cmConditionsOptions" :class="(error.field == 'conditions') ? 'is-invalid' : ''" class ="collapse-codemirror"/>
       </b-form-group>
 
       <b-form-group>
         <label>Message Mark-up</label>
-        <codemirror v-model="messageTemplate.message_markup" :options="cmMarkupOptions" :class="(error.field == 'message_markup') ? 'is-invalid' : ''"/>
+        <codemirror v-model="messageTemplate.message_markup" :options="cmMarkupOptions" :class="(error.field == 'message_markup') ? 'is-invalid' : ''" class="collapse-codemirror"/>
       </b-form-group>
 
       <b-card>
@@ -63,7 +63,7 @@ export default {
         mode: 'text/yaml',
         theme: 'dracula',
         lineNumbers: true,
-        line: true,
+        line: true
       },
       messageTemplate: null,
       error: {},

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -51,6 +51,9 @@ $simple-line-font-path: '~simple-line-icons/fonts/';
 }
 .collapse-codemirror {
     .CodeMirror {
-        height: auto
+        height: auto;
+    }
+    .CodeMirror-scroll {
+        max-height: 300px;
     }
 }

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -49,3 +49,8 @@ $simple-line-font-path: '~simple-line-icons/fonts/';
         cursor: not-allowed;
     }
 }
+.collapse-codemirror {
+    .CodeMirror {
+        height: auto
+    }
+}


### PR DESCRIPTION
This PR allows CodeMirror components to be tidied up and render to the height of their content. 
By adding a class of `collapse-codemirror'
![image](https://user-images.githubusercontent.com/1316576/85588261-74abdc80-b63a-11ea-8957-7216c2533e99.png)
