### PR TITLE
Removing conversation & webchat setup commands from docker-update.sh

### DIFF
--- a/scripts/update-docker.sh
+++ b/scripts/update-docker.sh
@@ -5,12 +5,6 @@ set -e
 echo "Setting up the database..."
 php artisan migrate --force
 
-echo "Populating default webchat settings..."
-php artisan webchat:setup
-
-echo "Creating example conversations..."
-php artisan conversations:setup --non-interactive
-
 echo "Creating admin user"
 php artisan admin_user:create
 


### PR DESCRIPTION
This PR removes conversation & webchat setup commands from `docker-update.sh`. This script can be run by deploys to ensure the databases are correctly populated. It seems better practice for our OpenDialog Artisan commands (`conversations:setup` & `webchat:setup`) to be run manually on a deploy as opposed to automatically. Both commands are potentially destructive to important data and should therefore only be run when necessary and at the discretion of the developer(s).