### PR TITLE
Fixing invalid v-if that stopped conversation log from displaying

### DIFF
--- a/resources/js/views/ConversationLog.vue
+++ b/resources/js/views/ConversationLog.vue
@@ -37,7 +37,7 @@
               </template>
             </div>
           </template>
-          <template v-if="message.type == 'rich' || v-if="message.type == 'fp-rich'">
+          <template v-if="message.type == 'rich' || message.type == 'fp-rich'">
             <div class="rich-message">
               <div class="rich-message--title mb-1" v-if="message.data.title">{{ message.data.title }}</div>
               <div class="rich-message--subtitle mb-2" v-if="message.data.subtitle">{{ message.data.subtitle }}</div>
@@ -109,9 +109,9 @@
 </template>
 
 <script>
-    import Breadcrumbs from "@/components/breadcrumbs/Breadcrumbs";
+import Breadcrumbs from "@/components/breadcrumbs/Breadcrumbs";
 
-    export default {
+export default {
   name: 'conversation-log',
   props: ['id'],
   components: {


### PR DESCRIPTION
This PR fixes an invalid `v-if` statement that stopped conversation log from displaying at all. This bug seems to have existed for some time, and therefore this component in general could do with an update in the near future. It could likely make use of the message preview work (seen in PR's such as #160).