### PR TITLE
Fixing specification & conversation import endpoints bug

### DIFF
--- a/app/Console/Commands/Specification/ImportSpecification.php
+++ b/app/Console/Commands/Specification/ImportSpecification.php
@@ -2,10 +2,10 @@
 
 namespace App\Console\Commands\Specification;
 
+use App\ImportExportHelpers\ConversationImportExportHelper;
+use App\ImportExportHelpers\IntentImportExportHelper;
+use App\ImportExportHelpers\MessageImportExportHelper;
 use Illuminate\Console\Command;
-use OpenDialogAi\ConversationBuilder\Conversation;
-use OpenDialogAi\Core\Conversation\Conversation as ConversationNode;
-use OpenDialogAi\ResponseEngine\OutgoingIntent;
 
 class ImportSpecification extends Command
 {
@@ -22,27 +22,9 @@ class ImportSpecification extends Command
         }
 
         if ($continue) {
-            $outgoingIntents = OutgoingIntent::all();
-            $conversations = Conversation::all();
-
-            foreach ($outgoingIntents as $outgoingIntent) {
-                $outgoingIntent->delete();
-
-                $this->info(sprintf('Deleted outgoing intent %s', $outgoingIntent->name));
-            }
-
-            foreach ($conversations as $conversation) {
-                if ($conversation->status == ConversationNode::ACTIVATED) {
-                    $conversation->deactivateConversation();
-                    $conversation->archiveConversation();
-                } elseif ($conversation->status == ConversationNode::DEACTIVATED) {
-                    $conversation->archiveConversation();
-                }
-
-                $conversation->delete();
-
-                $this->info(sprintf('Deleted conversation %s', $conversation->name));
-            }
+            MessageImportExportHelper::deleteExistingMessages($this);
+            IntentImportExportHelper::deleteExistingIntents($this);
+            ConversationImportExportHelper::deleteExistingConversations($this);
 
             $this->call(
                 'conversations:import',

--- a/app/Http/Controllers/API/SpecificationController.php
+++ b/app/Http/Controllers/API/SpecificationController.php
@@ -86,6 +86,10 @@ class SpecificationController extends Controller
             ], 400);
         }
 
+        MessageImportExportHelper::deleteExistingMessages();
+        IntentImportExportHelper::deleteExistingIntents();
+        ConversationImportExportHelper::deleteExistingConversations();
+
         foreach ($messageFiles as $fileName => $file) {
             resolve(OutgoingIntentsController::class)->importMessageFile($fileName, $file);
         }

--- a/app/ImportExportHelpers/IntentImportExportHelper.php
+++ b/app/ImportExportHelpers/IntentImportExportHelper.php
@@ -5,6 +5,7 @@ namespace App\ImportExportHelpers;
 
 use App\ImportExportHelpers\Generator\IntentFileGenerator;
 use App\ImportExportHelpers\Generator\InvalidFileFormatException;
+use Illuminate\Console\Command;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use OpenDialogAi\ResponseEngine\OutgoingIntent;
 
@@ -115,5 +116,19 @@ class IntentImportExportHelper extends BaseImportExportHelper
         $newIntent->save();
 
         return $fileGenerator;
+    }
+
+    /**
+     * @param Command|null $io
+     */
+    public static function deleteExistingIntents(Command $io = null): void
+    {
+        $outgoingIntents = OutgoingIntent::all();
+
+        foreach ($outgoingIntents as $outgoingIntent) {
+            $outgoingIntent->delete();
+
+            is_null($io) ?: $io->info(sprintf('Deleted outgoing intent %s', $outgoingIntent->name));
+        }
     }
 }

--- a/app/ImportExportHelpers/MessageImportExportHelper.php
+++ b/app/ImportExportHelpers/MessageImportExportHelper.php
@@ -134,4 +134,18 @@ class MessageImportExportHelper extends BaseImportExportHelper
 
         return $messageFileGenerator;
     }
+
+    /**
+     * @param Command|null $io
+     */
+    public static function deleteExistingMessages(Command $io = null): void
+    {
+        $messageTemplates = MessageTemplate::all();
+
+        foreach ($messageTemplates as $messageTemplate) {
+            $messageTemplate->delete();
+
+            is_null($io) ?: $io->info(sprintf('Deleted outgoing intent %s', $messageTemplate->name));
+        }
+    }
 }

--- a/tests/Feature/ImportExportConversationsTest.php
+++ b/tests/Feature/ImportExportConversationsTest.php
@@ -5,6 +5,8 @@ namespace Tests\Feature;
 use App\ImportExportHelpers\ConversationImportExportHelper;
 use Illuminate\Support\Facades\Artisan;
 use OpenDialogAi\ConversationBuilder\Conversation;
+use OpenDialogAi\ConversationEngine\ConversationStore\DGraphConversationQueryFactory;
+use OpenDialogAi\Core\Graph\DGraph\DGraphClient;
 
 /**
  * Class ImportExportConversationsTest
@@ -17,14 +19,28 @@ class ImportExportConversationsTest extends BaseSpecificationTest
     {
         $this->assertDatabaseMissing('conversations', ['name' => 'no_match_conversation']);
 
+        $this->assertEmpty(
+            resolve(DGraphClient::class)
+                ->query(DGraphConversationQueryFactory::getConversationTemplateIds())
+                ->getData()
+        );
+
         Artisan::call(
             'conversations:import',
             [
-                '--yes' => true
+                '--yes' => true,
+                '--activate' => true,
             ]
         );
 
         $this->assertDatabaseHas('conversations', ['name' => 'no_match_conversation']);
+
+        $this->assertCount(
+            2,
+            resolve(DGraphClient::class)
+                ->query(DGraphConversationQueryFactory::getConversationTemplateIds())
+                ->getData()
+        );
     }
 
     public function testExportConversations()

--- a/tests/Feature/ImportExportSpecificationTest.php
+++ b/tests/Feature/ImportExportSpecificationTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature;
 
-use App\Console\Commands\Specification\BaseSpecificationCommand;
 use App\ImportExportHelpers\MessageImportExportHelper;
 use Illuminate\Support\Facades\Artisan;
 use OpenDialogAi\ResponseEngine\MessageTemplate;

--- a/tests/Feature/ImportExportSpecificationTest.php
+++ b/tests/Feature/ImportExportSpecificationTest.php
@@ -4,6 +4,8 @@ namespace Tests\Feature;
 
 use App\ImportExportHelpers\MessageImportExportHelper;
 use Illuminate\Support\Facades\Artisan;
+use OpenDialogAi\ConversationEngine\ConversationStore\DGraphConversationQueryFactory;
+use OpenDialogAi\Core\Graph\DGraph\DGraphClient;
 use OpenDialogAi\ResponseEngine\MessageTemplate;
 
 /**
@@ -19,16 +21,30 @@ class ImportExportSpecificationTest extends BaseSpecificationTest
         $this->assertDatabaseMissing('outgoing_intents', ['name' => 'intent.core.NoMatchResponse']);
         $this->assertDatabaseMissing('message_templates', ['name' => 'Did not understand']);
 
+        $this->assertEmpty(
+            resolve(DGraphClient::class)
+                ->query(DGraphConversationQueryFactory::getConversationTemplateIds())
+                ->getData()
+        );
+
         Artisan::call(
             'specification:import',
             [
-                '--yes' => true
+                '--yes' => true,
+                '--activate' => true,
             ]
         );
 
         $this->assertDatabaseHas('conversations', ['name' => 'no_match_conversation']);
         $this->assertDatabaseHas('outgoing_intents', ['name' => 'intent.core.NoMatchResponse']);
         $this->assertDatabaseHas('message_templates', ['name' => 'Did not understand']);
+
+        $this->assertCount(
+            2,
+            resolve(DGraphClient::class)
+                ->query(DGraphConversationQueryFactory::getConversationTemplateIds())
+                ->getData()
+        );
     }
 
     public function testExportSpecification()

--- a/tests/Feature/SpecificationsTest.php
+++ b/tests/Feature/SpecificationsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\ImportExportHelpers\ConversationImportExportHelper;
+use App\User;
+use Illuminate\Http\UploadedFile;
+use OpenDialogAi\ConversationEngine\ConversationStore\DGraphConversationQueryFactory;
+use OpenDialogAi\Core\Graph\DGraph\DGraphClient;
+use Tests\TestCase;
+
+class SpecificationsTest extends TestCase
+{
+    protected $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->initDDgraph();
+
+        $this->user = factory(User::class)->create();
+    }
+
+    public function testSpecificationImportEndpoint()
+    {
+        $this->assertDatabaseMissing('conversations', ['name' => 'no_match_conversation']);
+
+        $this->assertEmpty(
+            resolve(DGraphClient::class)
+                ->query(DGraphConversationQueryFactory::getAllOpeningIntents())
+                ->getData()
+        );
+
+        $conversationFileName = ConversationImportExportHelper::addConversationFileExtension('no_match_conversation');
+        $conversationFile = UploadedFile::fake()->createWithContent(
+            $conversationFileName,
+            ConversationImportExportHelper::getConversationFileData(
+                ConversationImportExportHelper::getConversationPath($conversationFileName)
+            )
+        );
+
+        $this->actingAs($this->user, 'api')
+            ->post('/admin/api/specification-import', [
+                'file1' => $conversationFile
+            ])
+            ->assertStatus(200);
+
+        $this->assertDatabaseHas('conversations', ['name' => 'no_match_conversation']);
+
+        $this->assertCount(
+            1,
+            resolve(DGraphClient::class)
+                ->query(DGraphConversationQueryFactory::getAllOpeningIntents())
+                ->getData()
+        );
+
+        // Ensure re-importing works as expected (eg. that existing conversation activation is handled correctly)
+        $this->actingAs($this->user, 'api')
+            ->post('/admin/api/specification-import', [
+                'file1' => $conversationFile
+            ])
+            ->assertStatus(200);
+
+        $this->assertCount(
+            1,
+            resolve(DGraphClient::class)
+                ->query(DGraphConversationQueryFactory::getAllOpeningIntents())
+                ->getData()
+        );
+    }
+}


### PR DESCRIPTION
This PR fixes a bug with specification & conversation import endpoints that caused previous versions of conversations to not be deactivated. This caused inconsistencies in the user's conversation with the application as previous versions of the conversations were being returned on graph queries.

The crux of the issue was in these lines, in which the stored graph UID of the current conversation was removed and therefore removed the possibility of [properly deactivating the previous version](https://github.com/opendialogai/core/blob/d66aba2e21e3e819fd81d11da24c0bc821d29be5/src/ConversationBuilder/Conversation.php#L266-L268).

https://github.com/opendialogai/opendialog/blob/43cc83387bf3b42f0ca95b62f65bb732e682100a/app/ImportExportHelpers/ConversationImportExportHelper.php#L132-L137