### PR TITLE
Feature/OPDLG 330  Dynamic attributes

### DIFF
--- a/app/Console/Commands/Specification/ExportDynamicAttributes.php
+++ b/app/Console/Commands/Specification/ExportDynamicAttributes.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Console\Commands\Specification;
+
+use App\Http\Resources\DynamicAttributeCollection;
+use App\ImportExportHelpers\DynamicAttributeImportExportHelper;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Collection;
+use OpenDialogAi\Core\DynamicAttribute;
+
+class ExportDynamicAttributes extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'dynamic-attributes:export {name=custom-attributes} {--overwrite} {--y|yes}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Exports all dynamic attributes to file with given name.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $name = $this->argument('name');
+
+        $continue = $this->option('yes') ? true : $this->confirm('Do you want to export all dynamic attributes?');
+
+        if ($continue) {
+            $overwrite = $this->option('overwrite');
+            if (DynamicAttributeImportExportHelper::exists($name)) {
+                if ($overwrite === true) {
+                    $continue = true;
+                }
+                if ($overwrite === false) {
+                    $this->info('A dynamic-attributes file already exists. Use the --overwrite flag to overwrite it.');
+                    $continue = false;
+                }
+                if ($overwrite === null) {
+                    $continue = $this->confirm('A dynamic-attributes file already exists. Do you want to overwrite it?');
+                }
+            }
+        }
+
+        if ($continue) {
+            $this->exportDynamicAttributes(DynamicAttribute::all(), $name);
+            $this->info('Export of dynamic attributes finished.');
+        } else {
+            $this->info('Bye!');
+        }
+    }
+
+
+    /**
+     * Exports a collection of dynamic attributes to a file.
+     *
+     * @param Collection $collection
+     * @param string $name
+     */
+    protected function exportDynamicAttributes(Collection $collection, string $name)
+    {
+        $filePath = DynamicAttributeImportExportHelper::getFilePath($name);
+        $this->info(sprintf("Exporting dynamic attributes to $filePath ..."));
+
+        DynamicAttributeImportExportHelper::overwrite(DynamicAttributeCollection::toDictionary($collection), $filePath);
+    }
+
+
+}

--- a/app/Console/Commands/Specification/ImportDynamicAttributes.php
+++ b/app/Console/Commands/Specification/ImportDynamicAttributes.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Console\Commands\Specification;
+
+use App\Http\Controllers\API\DynamicAttributesController;
+use App\Http\Resources\DynamicAttributeCollection;
+use App\ImportExportHelpers\DynamicAttributeImportExportHelper;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use OpenDialogAi\Core\DynamicAttribute;
+
+
+class ImportDynamicAttributes extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'dynamic-attributes:import {name=custom-attributes} {--delete-existing} {--y|yes}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Imports all dynamic attributes from the file with the given name.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $name = $this->argument('name');
+        $filePath = DynamicAttributeImportExportHelper::getFilePath($name);
+
+        $continue = $this->option('yes') ?
+            true :
+            $this->confirm(
+                sprintf('Do you want to import all dynamic attributes from %s (%s) ?', $name, $filePath)
+            );
+
+        if ($continue) {
+            $deleteExisting = $this->option('delete-existing');
+            $this->info('Importing dynamic attributes...');
+
+            if ($collection = $this->importDynamicAttributes($name)) {
+                try {
+                    DB::transaction(function () use ($collection, $deleteExisting) {
+                        if ($deleteExisting) {
+                            $this->info("Deleting existing dynamic attributes...");
+                            DynamicAttribute::truncate();
+                        }
+                        foreach ($collection as $attribute) {
+                            $attribute->save();
+                        }
+                    });
+                    $this->info('Import of dynamic attributes finished.');
+                } catch (QueryException $e) {
+                    $this->error("Unexpected error occurred saving dynamic attributes.");
+                }
+            } else {
+                $this->error("Failed to create collection. Bailing...");
+                return;
+            }
+        }
+    }
+
+
+    /**
+     * @param string $name
+     * @param bool $deleteExisting
+     * @return DynamicAttributeCollection
+     */
+    protected function importDynamicAttributes(string $name): ?DynamicAttributeCollection
+    {
+        $filePath = DynamicAttributeImportExportHelper::getFilePath($name);
+        try {
+            $data = DynamicAttributeImportExportHelper::getFileData($filePath);
+            $dict = DynamicAttributeImportExportHelper::importFromString($data);
+            if ($error = DynamicAttributesController::validateImport($dict)) {
+                $this->error(json_encode($error, JSON_PRETTY_PRINT));
+                return null;
+            }
+            return DynamicAttributeCollection::fromDictionary($dict);
+        } catch (FileNotFoundException $exception) {
+            $this->error(sprintf('Could not find dynamic attributes file at at %s', $filePath));
+            return null;
+        } catch (\JsonException $e) {
+            $this->error($e->getMessage());
+            return null;
+        }
+    }
+}

--- a/app/Http/Controllers/API/DynamicAttributesController.php
+++ b/app/Http/Controllers/API/DynamicAttributesController.php
@@ -26,6 +26,90 @@ class DynamicAttributesController extends Controller
         $this->middleware('auth');
     }
 
+    /**
+     * Upload a JSON object of { attribute_id: attribute_type } pairs
+     * as DynamicAttributes.
+     *
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public static function upload(Request $request): Response
+    {
+        $data = $request->all();
+        if ($error = self::validateImport($data)) {
+            return response($error, 400);
+        }
+
+        try {
+            DB::transaction(function () use ($data) {
+                foreach ($data as $id => $type) {
+                    DynamicAttribute::create(['attribute_id' => $id, 'attribute_type' => $type]);
+                }
+            });
+            return response($data, 201);
+        } catch (QueryException $e) {
+            return response(
+                "Unexpected occurred saving uploaded dynamic attributes.",
+                500
+            );
+        }
+    }
+
+    /**
+     * Validate uploaded DynamicAttributes
+     *
+     * @param array $data
+     *
+     * @return array|null
+     */
+    public static function validateImport(array $data): ?array
+    {
+        if (empty($data)) {
+            return [
+                'message' => 'No data in upload. Upload be a JSON object in of the form:
+ { <attribute_id>: attribute.<component>.<attribute_type> }',
+            ];
+        }
+
+        $invalidIds = array_filter(
+            array_keys($data),
+            fn($id) => !DynamicAttribute::isValidId($id)
+        );
+        if (!empty($invalidIds)) {
+            return [
+                'ids' => $invalidIds,
+                'message' => 'Invalid attribute ids in upload. All attribute Ids must be in snake_case',
+            ];
+        }
+
+        $invalidTypes = array_filter(
+            array_values($data),
+            fn($type) => !DynamicAttribute::isValidType($type)
+        );
+        if (!empty($invalidTypes)) {
+            return [
+                'types' => $invalidTypes,
+                'message' => 'Invalid attribute types in upload. All attribute types must be in the following format:
+ attribute.<component>.<type>',
+            ];
+        }
+
+        $ids = array_keys($data);
+        $existing = DynamicAttribute::whereIn('attribute_id', $ids);
+        /* Todo: Check for existing attributes in config */
+        if ($existing->count() > 0) {
+            return [
+                'ids' => $existing->get()->map(fn($item) => $item->id),
+                'message' => 'Some ids in upload are already in use.',
+            ];
+        }
+
+        $types = array_values($data);
+        // Todo: Check if the types exist.
+
+        return null;
+    }
 
     /**
      * Display a listing of the resource.
@@ -36,7 +120,6 @@ class DynamicAttributesController extends Controller
     {
         return new DynamicAttributeCollection(DynamicAttribute::paginate(50));
     }
-
 
     /**
      * Store a newly created resource in storage.
@@ -53,12 +136,13 @@ class DynamicAttributesController extends Controller
             return response($error, 400);
         }
 
-        if (DynamicAttribute::find($dynamicAttribute->id) || false /* TODO: Check for existing attributes from config */) {
+        if (DynamicAttribute::where('attribute_id', $dynamicAttribute->attribute_id)->exists()
+            || false /* TODO: Check for existing attributes from config */) {
             return response([
-                'field' => 'id',
+                'field' => 'attribute_id',
                 'message' => sprintf(
-                    "Id '%s' is already in use.",
-                    $dynamicAttribute->id
+                    "Attribute ID '%s' is already in use.",
+                    $dynamicAttribute->attribute_id
                 ),
             ], 400);
         }
@@ -68,8 +152,8 @@ class DynamicAttributesController extends Controller
         } catch (QueryException $e) {
             return response(
                 [
-                'attribute' => $dynamicAttribute->toJson(),
-                'message' => "Unexpected occurred saving dynamic attribute",
+                    'attribute' => $dynamicAttribute->toJson(),
+                    'message' => "Unexpected error occurred saving dynamic attribute",
                 ],
                 500
             );
@@ -85,34 +169,34 @@ class DynamicAttributesController extends Controller
      */
     private function validateValue(DynamicAttribute $dynamicAttribute): ?array
     {
-        if (empty($dynamicAttribute->id)) {
+        if (empty($dynamicAttribute->attribute_id)) {
             return [
-                'field' => 'id',
-                'message' => 'Attribute ID field is required.',
+                'field' => 'attribute_id',
+                'message' => 'attribute_id field is required.',
             ];
         }
 
-        if (empty($dynamicAttribute->type)) {
+        if (empty($dynamicAttribute->attribute_type)) {
             return [
-                'field' => 'type',
-                'message' => 'Type field is required.',
+                'field' => 'attribute_type',
+                'message' => 'attribute_type field is required.',
             ];
         }
 
-        if ($dynamicAttribute->id) {
-            if (!DynamicAttribute::isValidId($dynamicAttribute->id)) {
+        if ($dynamicAttribute->attribute_id) {
+            if (!DynamicAttribute::isValidId($dynamicAttribute->attribute_id)) {
                 return [
-                    'field' => 'id',
-                    'message' => 'ID field must follow snake_case format.',
+                    'field' => 'attribute_id',
+                    'message' => 'attribute_id field must follow snake_case format.',
                 ];
             }
         }
 
-        if ($dynamicAttribute->type) {
-            if (!DynamicAttribute::isValidType($dynamicAttribute->type)) {
+        if ($dynamicAttribute->attribute_type) {
+            if (!DynamicAttribute::isValidType($dynamicAttribute->attribute_type)) {
                 return [
-                    'field' => 'type',
-                    'message' => "Type field must follow the format: 'attribute.<component_name>.<type>'",
+                    'field' => 'attribute_type',
+                    'message' => "attribute_type field must follow the format: 'attribute.<component_name>.<type>'",
                 ];
             }
         }
@@ -127,11 +211,11 @@ class DynamicAttributesController extends Controller
     /**
      * Display the specified resource.
      *
-     * @param string $id
+     * @param int $id
      *
      * @return DynamicAttributeResource
      */
-    public function show(string $id): DynamicAttributeResource
+    public function show(int $id): DynamicAttributeResource
     {
         if ($dynamicAttribute = DynamicAttribute::find($id)) {
             return new DynamicAttributeResource($dynamicAttribute);
@@ -144,27 +228,27 @@ class DynamicAttributesController extends Controller
      * Update the specified resource in storage.
      *
      * @param Request $request
-     * @param string $id
+     * @param int $id
      *
      * @return Response
      */
-    public function update(Request $request, string $id): Response
+    public function update(Request $request, int $id): Response
     {
         if ($dynamicAttribute = DynamicAttribute::find($id)) {
             $dynamicAttribute->fill($request->all());
 
-            /* If we're changing an existing DynamicAttribute's id, check for duplicates */
-            if ($dynamicAttribute->id !== $id) {
-                if (DynamicAttribute::find($dynamicAttribute->id)
-                    || false /* TODO: Check for existing attributes from config */) {
-                    return response([
-                        'field' => 'id',
-                        'message' => sprintf(
-                            "Id '%s' is already in use.",
-                            $dynamicAttribute->id
-                        ),
-                    ], 400);
-                }
+            $sameAttributeId = DynamicAttribute::where([
+                ['attribute_id', $dynamicAttribute->attribute_id],
+                ['id', '<>', $dynamicAttribute->id]
+            ])->get();
+            if ($sameAttributeId->count() > 0 || false /* TODO: Check for existing attributes from config */) {
+                return response([
+                    'field' => 'attribute_id',
+                    'message' => sprintf(
+                        "Attribute id '%s' is already in use.",
+                        $dynamicAttribute->attribute_id
+                    ),
+                ], 400);
             }
 
             if ($error = $this->validateValue($dynamicAttribute)) {
@@ -188,16 +272,16 @@ class DynamicAttributesController extends Controller
     /**
      * Remove the specified resource from storage.
      *
-     * @param string $id
+     * @param int $id
      *
      * @return Response
      */
-    public function destroy(string $id): Response
+    public function destroy(int $id): Response
     {
         if ($dynamicAttribute = DynamicAttribute::find($id)) {
             try {
                 $dynamicAttribute->delete();
-                return response()->noContent(200);
+                return response()->noContent();
             } catch (Exception $e) {
                 return response(sprintf(
                     'Error deleting DynamicAttribute %s',
@@ -218,98 +302,12 @@ class DynamicAttributesController extends Controller
     {
         $map = [];
         foreach (DynamicAttribute::all() as $dynamicAttribute) {
-            $map[$dynamicAttribute->id] = $dynamicAttribute->type;
+            $map[$dynamicAttribute->attribute_id] = $dynamicAttribute->attribute_type;
         }
         return new JsonResponse(
             $map,
             200,
-            ['Content-Disposition' => 'attachment; filename="dynamic-attributes.json"']
+            ['Content-Disposition' => 'attachment; filename="custom-attributes.json"']
         );
-    }
-
-
-    /**
-     * Upload a JSON object of { attribute_id: attribute_type } pairs
-     * as DynamicAttributes.
-     *
-     * @param Request $request
-     *
-     * @return Response
-     */
-    public function upload(Request $request): Response
-    {
-        $data = $request->all();
-        if ($error = $this->validateUpload($data)) {
-            return response($error, 400);
-        }
-
-        try {
-            DB::transaction(function () use ($data) {
-                foreach ($data as $id => $type) {
-                    DynamicAttribute::create(['id' => $id, 'type' => $type]);
-                }
-            });
-            return response($data, 201);
-        } catch (QueryException $e) {
-            return response(
-                "Unexpected occurred saving uploaded dynamic attributes.",
-                500
-            );
-        }
-    }
-
-    /**
-     * Validate uploaded DynamicAttributes
-     *
-     * @param array $data
-     *
-     * @return array|null
-     */
-    public function validateUpload(array $data): ?array
-    {
-        if (empty($data)) {
-            return [
-                'message' => 'Unable to parse upload body. Uploads must be a JSON object in of the form:
- { <attribute_id>: attribute.<component>.<attribute_type> }',
-            ];
-        }
-
-        $invalidIds = array_filter(
-            array_keys($data),
-            fn ($id) => !DynamicAttribute::isValidId($id)
-        );
-        if (!empty($invalidIds)) {
-            return [
-                'ids' => $invalidIds,
-                'message' => 'Invalid attribute ids in upload. All attribute Ids must be in snake_case',
-            ];
-        }
-
-        $invalidTypes = array_filter(
-            array_values($data),
-            fn ($type) => !DynamicAttribute::isValidType($type)
-        );
-        if (!empty($invalidTypes)) {
-            return [
-                'types' => $invalidTypes,
-                'message' => 'Invalid attribute types in upload. All attribute types must be in the following format:
- attribute.<component>.<type>',
-            ];
-        }
-
-        $ids = array_keys($data);
-        $existing = DynamicAttribute::whereIn('id', $ids);
-        /* Todo: Check for existing attributes in config */
-        if ($existing->count() > 0) {
-            return [
-                'ids' => $existing->get()->map(fn ($item) => $item->id),
-                'message' => 'Some ids in upload are already in use.',
-            ];
-        }
-
-        $types = array_values($data);
-        // Todo: Check if the types exist.
-
-        return null;
     }
 }

--- a/app/Http/Controllers/API/DynamicAttributesController.php
+++ b/app/Http/Controllers/API/DynamicAttributesController.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\DynamicAttributeCollection;
+use App\Http\Resources\DynamicAttributeResource;
+use Exception;
+use Illuminate\Database\QueryException;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Log;
+use OpenDialogAi\Core\DynamicAttribute;
+
+class DynamicAttributesController extends Controller
+{
+
+    /**
+     * Create a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->middleware('auth');
+    }
+
+
+    /**
+     * Display a listing of the resource.
+     *
+     * @return DynamicAttributeCollection
+     */
+    public function index(): DynamicAttributeCollection
+    {
+        return new DynamicAttributeCollection(DynamicAttribute::paginate(50));
+    }
+
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  Request  $request
+     *
+     * @return Response
+     */
+    public function store(Request $request)
+    {
+        /*
+            @var $dynamicAttribute DynamicAttribute
+        */
+        $dynamicAttribute = DynamicAttribute::make($request->all());
+
+        if ($existing = DynamicAttribute::find($dynamicAttribute->id)) {
+            return response([
+                'field' => 'id',
+                'message' => sprintf(
+                    "ID '%s' is already in use.",
+                    $dynamicAttribute->id
+                ),
+            ], 400);
+        }
+
+        if ($error = $this->validateValue($dynamicAttribute)) {
+            return response($error, 400);
+        }
+
+        try {
+            $dynamicAttribute->save();
+        } catch (QueryException $e) {
+            return response(
+                "Unexpected occurred saving dynamic attribute.",
+                500
+            );
+        }
+
+        return new DynamicAttributeResource($dynamicAttribute);
+    }
+
+    /**
+     * @param  DynamicAttribute  $dynamicAttribute
+     *
+     * @return array
+     */
+    private function validateValue(DynamicAttribute $dynamicAttribute): ?array
+    {
+        if (empty($dynamicAttribute->id)) {
+            return [
+                'field' => 'id',
+                'message' => 'Attribute ID field is required.',
+            ];
+        }
+
+        if (empty($dynamicAttribute->type)) {
+            return [
+                'field' => 'type',
+                'message' => 'Type field is required.',
+            ];
+        }
+
+        if ($dynamicAttribute->id) {
+            if (!DynamicAttribute::isValidId($dynamicAttribute->id)) {
+                return [
+                    'field' => 'id',
+                    'message' => 'ID field must follow snake_case format.',
+                ];
+            }
+        }
+
+        if ($dynamicAttribute->type) {
+            if (!DynamicAttribute::isValidType($dynamicAttribute->type)) {
+                return [
+                    'field' => 'type',
+                    'message' => "Type field must follow the format: 'attribute.<component_name>.<type>'",
+                ];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  string  $id
+     *
+     * @return DynamicAttributeResource
+     */
+    public function show(string $id): DynamicAttributeResource
+    {
+        if ($dynamicAttribute = DynamicAttribute::find($id)) {
+            return new DynamicAttributeResource($dynamicAttribute);
+        }
+
+        return response()->noContent(404);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  Request  $request
+     * @param  string  $id
+     *
+     * @return Response
+     */
+    public function update(Request $request, string $id): Response
+    {
+        /*
+            @var DynamicAttribute $dynamicAttribute
+        */
+        if ($dynamicAttribute = DynamicAttribute::find($id)) {
+            $dynamicAttribute->fill($request->all());
+
+            if ($error = $this->validateValue($dynamicAttribute)) {
+                return response($error, 400);
+            }
+
+            $dynamicAttribute->save();
+
+            return response()->noContent();
+        }
+
+        return response()->noContent(404);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  string  $id
+     *
+     * @return Response
+     */
+    public function destroy(string $id): Response
+    {
+        /*
+            @var DynamicAttribute $user
+        */
+        if ($dynamicAttribute = DynamicAttribute::find($id)) {
+            try {
+                $dynamicAttribute->delete();
+                return response()->noContent(200);
+            } catch (Exception $e) {
+                Log::error(sprintf(
+                    'Error deleting DynamicAttribute - %s',
+                    $e->getMessage()
+                ));
+                return response(sprintf(
+                    'Error deleting DynamicAttribute %s',
+                    $dynamicAttribute->id
+                ), 500);
+            }
+        }
+
+        return response()->noContent(404);
+    }
+}

--- a/app/Http/Controllers/API/DynamicAttributesController.php
+++ b/app/Http/Controllers/API/DynamicAttributesController.php
@@ -11,6 +11,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\DB;
+use OpenDialogAi\ContextEngine\AttributeResolver\AttributeResolver as AttributeResolverAlias;
 use OpenDialogAi\Core\DynamicAttribute;
 
 class DynamicAttributesController extends Controller
@@ -83,7 +84,7 @@ class DynamicAttributesController extends Controller
 
         $invalidIds = array_filter(
             array_keys($data),
-            fn($attribute_id) => !DynamicAttribute::isValidId($attribute_id)
+            fn($attribute_id) => !AttributeResolverAlias::isValidId($attribute_id)
         );
         if (!empty($invalidIds)) {
             return [
@@ -94,7 +95,7 @@ class DynamicAttributesController extends Controller
 
         $invalidTypes = array_filter(
             array_values($data),
-            fn($attribute_type) => !DynamicAttribute::isValidType($attribute_type)
+            fn($attribute_type) => !AttributeResolverAlias::isValidType($attribute_type)
         );
         if (!empty($invalidTypes)) {
             return [
@@ -193,7 +194,7 @@ class DynamicAttributesController extends Controller
         }
 
         if ($dynamicAttribute->attribute_id) {
-            if (!DynamicAttribute::isValidId($dynamicAttribute->attribute_id)) {
+            if (!AttributeResolverAlias::isValidId($dynamicAttribute->attribute_id)) {
                 return [
                     'field' => 'attribute_id',
                     'message' => 'attribute_id field must follow snake_case format.',
@@ -202,7 +203,7 @@ class DynamicAttributesController extends Controller
         }
 
         if ($dynamicAttribute->attribute_type) {
-            if (!DynamicAttribute::isValidType($dynamicAttribute->attribute_type)) {
+            if (!AttributeResolverAlias::isValidType($dynamicAttribute->attribute_type)) {
                 return [
                     'field' => 'attribute_type',
                     'message' => "attribute_type field must follow the format: 'attribute.<component_name>.<type>'",

--- a/app/Http/Controllers/API/DynamicAttributesController.php
+++ b/app/Http/Controllers/API/DynamicAttributesController.php
@@ -65,6 +65,13 @@ class DynamicAttributesController extends Controller
      */
     public static function validateImport(array $data): ?array
     {
+        if (empty($data)) {
+            return [
+                'message' => 'The provided JSON contains no properties. You must provide JSON object of the form:
+ { <attribute_id>: attribute.<component>.<attribute_type>, ... }'
+            ];
+        }
+
         foreach ($data as $attribute_id => $attribute_type) {
             if (!is_string($attribute_id) || !is_string($attribute_type)) {
                 return [

--- a/app/Http/Resources/DynamicAttributeCollection.php
+++ b/app/Http/Resources/DynamicAttributeCollection.php
@@ -2,14 +2,46 @@
 
 namespace App\Http\Resources;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Resources\Json\ResourceCollection;
+use OpenDialogAi\Core\DynamicAttribute;
 
 class DynamicAttributeCollection extends ResourceCollection
 {
     /**
+     * Transform the collection into a dictionary of id => type pairs.
+     *
+     * @param Collection $collection
+     * @return array
+     */
+    public static function toDictionary(Collection $collection): array
+    {
+        $keyed = $collection->mapWithKeys(function ($attr) {
+            return [$attr['attribute_id'] => $attr['attribute_type']];
+        });
+        return $keyed->all();
+    }
+
+    /**
+     * Build a DynamicAttributeCollection
+     * from a dictionary of id => type pairs.
+     *
+     * @return DynamicAttributeCollection
+     */
+    public static function fromDictionary(array $dict): DynamicAttributeCollection
+    {
+        $array = [];
+        foreach ($dict as $id => $type) {
+            $array[] = DynamicAttribute::make(['attribute_id' => $id, 'attribute_type' => $type]);
+        }
+
+        return DynamicAttributeCollection::make($array);
+    }
+
+    /**
      * Transform the resource collection into an array.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param \Illuminate\Http\Request $request
      * @return array
      */
     public function toArray($request)

--- a/app/Http/Resources/DynamicAttributeCollection.php
+++ b/app/Http/Resources/DynamicAttributeCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class DynamicAttributeCollection extends ResourceCollection
+{
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return parent::toArray($request);
+    }
+}

--- a/app/Http/Resources/DynamicAttributeResource.php
+++ b/app/Http/Resources/DynamicAttributeResource.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class DynamicAttributeResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return parent::toArray($request);
+    }
+}

--- a/app/ImportExportHelpers/DynamicAttributeImportExportHelper.php
+++ b/app/ImportExportHelpers/DynamicAttributeImportExportHelper.php
@@ -1,0 +1,37 @@
+<?php
+
+
+namespace App\ImportExportHelpers;
+
+class DynamicAttributeImportExportHelper extends BaseImportExportHelper
+{
+    const RESOURCE_DIRECTORY = 'custom-attributes';
+    const FILE_EXTENSION = ".json";
+
+    public static function overwrite(array $attrs, string $path)
+    {
+        self::getDisk()->put($path, json_encode($attrs, JSON_PRETTY_PRINT));
+    }
+
+    public static function exists(string $name)
+    {
+        $path = self::getFilePath($name);
+        return self::getDisk()->exists($path);
+    }
+
+    public static function getFilePath(string $name): string
+    {
+        return self::RESOURCE_DIRECTORY . "/$name" . self::FILE_EXTENSION;
+    }
+
+    public static function getFileData(string $filePath): string
+    {
+        return self::getDisk()->get($filePath);
+    }
+
+    public static function importFromString(string $data): array
+    {
+        return json_decode($data, true, 512, JSON_THROW_ON_ERROR);
+    }
+
+}

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "laravel/framework": "^6.0",
         "laravel/tinker": "^1.0",
         "maennchen/zipstream-php": "^2.0",
-        "opendialogai/core": "0.7.x-dev",
+        "opendialogai/core": "dev-feature/OPNDLG-330--dynamic-attributes-crud",
         "opendialogai/webchat": "0.7.x-dev",
         "phalcongelist/php-diff": "^2.0",
         "predis/predis": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -2228,12 +2228,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "4b09c222ad8dd8862a44e943cf3671612438b971"
+                "reference": "3fd32034da181c74617ba04dee009bf3aed2d9cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/4b09c222ad8dd8862a44e943cf3671612438b971",
-                "reference": "4b09c222ad8dd8862a44e943cf3671612438b971",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/3fd32034da181c74617ba04dee009bf3aed2d9cb",
+                "reference": "3fd32034da181c74617ba04dee009bf3aed2d9cb",
                 "shasum": ""
             },
             "require": {
@@ -2307,7 +2307,7 @@
                 "issues": "https://github.com/opendialogai/core/issues",
                 "source": "https://github.com/opendialogai/core/tree/feature/OPNDLG-330--dynamic-attributes-crud"
             },
-            "time": "2021-01-28T16:22:05+00:00"
+            "time": "2021-01-31T12:26:59+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/composer.lock
+++ b/composer.lock
@@ -2228,12 +2228,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "b5db1e7e9591ed82ccde7e354cb7890b96de1bd5"
+                "reference": "4b09c222ad8dd8862a44e943cf3671612438b971"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/b5db1e7e9591ed82ccde7e354cb7890b96de1bd5",
-                "reference": "b5db1e7e9591ed82ccde7e354cb7890b96de1bd5",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/4b09c222ad8dd8862a44e943cf3671612438b971",
+                "reference": "4b09c222ad8dd8862a44e943cf3671612438b971",
                 "shasum": ""
             },
             "require": {
@@ -2307,7 +2307,7 @@
                 "issues": "https://github.com/opendialogai/core/issues",
                 "source": "https://github.com/opendialogai/core/tree/feature/OPNDLG-330--dynamic-attributes-crud"
             },
-            "time": "2021-01-25T16:00:51+00:00"
+            "time": "2021-01-28T16:22:05+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/composer.lock
+++ b/composer.lock
@@ -2228,12 +2228,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "3fd32034da181c74617ba04dee009bf3aed2d9cb"
+                "reference": "8b17ed1f9956daaefee9d2090da34cf98d41c2ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/3fd32034da181c74617ba04dee009bf3aed2d9cb",
-                "reference": "3fd32034da181c74617ba04dee009bf3aed2d9cb",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/8b17ed1f9956daaefee9d2090da34cf98d41c2ef",
+                "reference": "8b17ed1f9956daaefee9d2090da34cf98d41c2ef",
                 "shasum": ""
             },
             "require": {
@@ -2307,7 +2307,7 @@
                 "issues": "https://github.com/opendialogai/core/issues",
                 "source": "https://github.com/opendialogai/core/tree/feature/OPNDLG-330--dynamic-attributes-crud"
             },
-            "time": "2021-01-31T12:26:59+00:00"
+            "time": "2021-02-01T10:53:39+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e301cfa42df8af64a732358fcaf0dae2",
+    "content-hash": "a78f6e8ad323e0ba8c2b8c657a7ccd0c",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -2224,16 +2224,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "0.7.x-dev",
+            "version": "dev-feature/OPNDLG-330--dynamic-attributes-crud",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "17a22a9d7445463cf02bfbf5cc28a16a6d93bb34"
+                "reference": "b5db1e7e9591ed82ccde7e354cb7890b96de1bd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/17a22a9d7445463cf02bfbf5cc28a16a6d93bb34",
-                "reference": "17a22a9d7445463cf02bfbf5cc28a16a6d93bb34",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/b5db1e7e9591ed82ccde7e354cb7890b96de1bd5",
+                "reference": "b5db1e7e9591ed82ccde7e354cb7890b96de1bd5",
                 "shasum": ""
             },
             "require": {
@@ -2258,7 +2258,6 @@
                 "phpunit/phpunit": "8.3.5",
                 "squizlabs/php_codesniffer": "^3.4"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -2306,9 +2305,9 @@
             "description": "The OpenDialog Core package",
             "support": {
                 "issues": "https://github.com/opendialogai/core/issues",
-                "source": "https://github.com/opendialogai/core/tree/0.7.4.1"
+                "source": "https://github.com/opendialogai/core/tree/feature/OPNDLG-330--dynamic-attributes-crud"
             },
-            "time": "2021-01-07T09:16:15+00:00"
+            "time": "2021-01-25T16:00:51+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/database/factories/DynamicAttributeFactory.php
+++ b/database/factories/DynamicAttributeFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+use App\Model;
+use Faker\Generator as Faker;
+use Illuminate\Database\Eloquent\Factory;
+use OpenDialogAi\Core\DynamicAttribute;
+
+/** @var Factory $factory */
+$factory->define(DynamicAttribute::class, function (Faker $faker) {
+    return [
+        'attribute_id' => $faker->unique()->regexify(DynamicAttribute::$validIdPattern),
+        'attribute_type' => $faker->regexify(DynamicAttribute::$validTypePattern)
+    ];
+});

--- a/database/factories/DynamicAttributeFactory.php
+++ b/database/factories/DynamicAttributeFactory.php
@@ -3,12 +3,13 @@
 use App\Model;
 use Faker\Generator as Faker;
 use Illuminate\Database\Eloquent\Factory;
+use OpenDialogAi\ContextEngine\AttributeResolver\AttributeResolver;
 use OpenDialogAi\Core\DynamicAttribute;
 
 /** @var Factory $factory */
 $factory->define(DynamicAttribute::class, function (Faker $faker) {
     return [
-        'attribute_id' => $faker->unique()->regexify(DynamicAttribute::$validIdPattern),
-        'attribute_type' => $faker->regexify(DynamicAttribute::$validTypePattern)
+        'attribute_id' => $faker->unique()->regexify(AttributeResolver::$validIdPattern),
+        'attribute_type' => $faker->regexify(AttributeResolver::$validTypePattern)
     ];
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,47 +17,93 @@ Route::middleware('auth:api')->get('/api/user', function (Request $request) {
     return $request->user();
 });
 
-Route::namespace('API')->middleware(['auth:api'])->prefix('admin/api')->group(function () {
-    Route::apiResource('conversation', 'ConversationsController');
-    Route::apiResource('webchat-setting', 'WebchatSettingsController', ['except' => ['store', 'destroy']]);
-    Route::apiResource('chatbot-user', 'ChatbotUsersController', ['except' => ['store', 'update', 'destroy']]);
-    Route::apiResource('user', 'UsersController');
+Route::namespace('API')
+    ->middleware(['auth:api'])
+    ->prefix('admin/api')
+    ->group(function () {
+        Route::apiResource('conversation', 'ConversationsController');
+        Route::apiResource(
+            'webchat-setting',
+            'WebchatSettingsController',
+            ['except' => ['store', 'destroy']]
+        );
+        Route::apiResource(
+            'chatbot-user',
+            'ChatbotUsersController',
+            ['except' => ['store', 'update', 'destroy']]
+        );
+        Route::apiResource('user', 'UsersController');
 
-    Route::apiResource('outgoing-intent', 'OutgoingIntentsController');
-    Route::get('outgoing-intent/{id}/export', 'OutgoingIntentsController@export');
-    Route::post('outgoing-intent/{id}/import', 'OutgoingIntentsController@import');
-    Route::apiResource('outgoing-intent/{id}/message-templates', 'MessageTemplatesController');
+        Route::apiResource('outgoing-intent', 'OutgoingIntentsController');
+        Route::get(
+            'outgoing-intent/{id}/export',
+            'OutgoingIntentsController@export'
+        );
+        Route::post(
+            'outgoing-intent/{id}/import',
+            'OutgoingIntentsController@import'
+        );
+        Route::apiResource(
+            'outgoing-intent/{id}/message-templates',
+            'MessageTemplatesController'
+        );
 
-    Route::apiResource('global-context', 'GlobalContextsController');
+        Route::apiResource('global-context', 'GlobalContextsController');
 
-    Route::get('conversation-archive', 'ConversationsController@viewArchive');
-    Route::prefix('conversation/{id}')->group(function () {
-        Route::get('/activate', 'ConversationsController@activate');
-        Route::get('/deactivate', 'ConversationsController@deactivate');
-        Route::get('/archive', 'ConversationsController@archive');
-        Route::get('/message-templates', 'ConversationsController@messageTemplates');
+        Route::apiResource('dynamic-attribute', 'DynamicAttributesController');
 
-        Route::get('/export', 'ConversationsController@export');
-        Route::post('/import', 'ConversationsController@import');
+        Route::get(
+            'conversation-archive',
+            'ConversationsController@viewArchive'
+        );
+        Route::prefix('conversation/{id}')->group(function () {
+            Route::get('/activate', 'ConversationsController@activate');
+            Route::get('/deactivate', 'ConversationsController@deactivate');
+            Route::get('/archive', 'ConversationsController@archive');
+            Route::get(
+                '/message-templates',
+                'ConversationsController@messageTemplates'
+            );
 
-        Route::get('/restore/{versionId}', 'ConversationsController@restore');
-        Route::get('/reactivate/{versionId}', 'ConversationsController@reactivate');
+            Route::get('/export', 'ConversationsController@export');
+            Route::post('/import', 'ConversationsController@import');
+
+            Route::get(
+                '/restore/{versionId}',
+                'ConversationsController@restore'
+            );
+            Route::get(
+                '/reactivate/{versionId}',
+                'ConversationsController@reactivate'
+            );
+        });
+
+        Route::get(
+            'chatbot-user/{id}/messages',
+            'ChatbotUsersController@messages'
+        );
+
+        Route::get('requests', 'RequestsController@index');
+        Route::get('requests/{id}', 'RequestsController@show');
+
+        Route::get('warnings', 'WarningsController@index');
+        Route::get('warnings/{id}', 'WarningsController@show');
+
+        Route::get('conversations/export', 'ConversationsController@exportAll');
+        Route::post(
+            'conversations/import',
+            'ConversationsController@importAll'
+        );
+
+        Route::get(
+            'outgoing-intents/export',
+            'OutgoingIntentsController@exportAll'
+        );
+        Route::post(
+            'outgoing-intents/import',
+            'OutgoingIntentsController@importAll'
+        );
+
+        Route::post('specification-import', 'SpecificationController@import');
+        Route::get('specification-export', 'SpecificationController@export');
     });
-
-    Route::get('chatbot-user/{id}/messages', 'ChatbotUsersController@messages');
-
-    Route::get('requests', 'RequestsController@index');
-    Route::get('requests/{id}', 'RequestsController@show');
-
-    Route::get('warnings', 'WarningsController@index');
-    Route::get('warnings/{id}', 'WarningsController@show');
-
-    Route::get('conversations/export', 'ConversationsController@exportAll');
-    Route::post('conversations/import', 'ConversationsController@importAll');
-
-    Route::get('outgoing-intents/export', 'OutgoingIntentsController@exportAll');
-    Route::post('outgoing-intents/import', 'OutgoingIntentsController@importAll');
-
-    Route::post('specification-import', 'SpecificationController@import');
-    Route::get('specification-export', 'SpecificationController@export');
-});

--- a/routes/api.php
+++ b/routes/api.php
@@ -50,6 +50,9 @@ Route::namespace('API')
 
         Route::apiResource('global-context', 'GlobalContextsController');
 
+        
+        Route::get('dynamic-attributes/download', 'DynamicAttributesController@download');
+        Route::post('dynamic-attributes/upload', 'DynamicAttributesController@upload');
         Route::apiResource('dynamic-attribute', 'DynamicAttributesController');
 
         Route::get(

--- a/tests/Feature/DynamicAttributesTest.php
+++ b/tests/Feature/DynamicAttributesTest.php
@@ -3,17 +3,26 @@
 namespace Tests\Feature;
 
 use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
 use OpenDialogAi\Core\DynamicAttribute;
 use Tests\TestCase;
 
 /**
  * Class DynamicAttributesTest
+ *
  * @package Tests\Feature
  * @group SpecificationTests
  */
 class DynamicAttributesTest extends TestCase
 {
-    const invalidIds = ['testDynamicAttribute', 'test_Dynamic.Attribute', 'test_dynamic_attribute_1', 'test_Dynamic.Attribute_1', 'testdynamicattribute1'];
+    use RefreshDatabase;
+    use WithFaker;
+
+    const invalidIds = [
+        'testDynamicAttribute', 'test_Dynamic.Attribute', 'test_dynamic_attribute_1', 'test_Dynamic.Attribute_1',
+        'testdynamicattribute1'
+    ];
     const invalidTypes = ['attributeCoreString', 'attribute.string', 'core.string', 'string', 'wrong.core.string'];
     protected $user;
 
@@ -23,223 +32,237 @@ class DynamicAttributesTest extends TestCase
 
         $this->user = factory(User::class)->create();
 
-        DynamicAttribute::truncate();
-
     }
 
-    public function testViewEndpoint()
+    public function testView()
     {
+        /* @var $dynamicAttribute DynamicAttribute */
         $dynamicAttribute = factory(DynamicAttribute::class)->create();
 
-        $this->get('/admin/api/dynamic-attribute/' . $dynamicAttribute->id)
-            ->assertStatus(302);
+        $this->get('/admin/api/dynamic-attribute/'.$dynamicAttribute->id)->assertStatus(302);
 
-        $this->actingAs($this->user, 'api')
-            ->json('GET', '/admin/api/dynamic-attribute/' . $dynamicAttribute->id)
-            ->assertStatus(200)
-            ->assertJsonFragment(
-                [
+        $this->actingAs($this->user, 'api')->json('GET',
+                '/admin/api/dynamic-attribute/'.$dynamicAttribute->id)->assertStatus(200)->assertJsonFragment([
                     'attribute_id' => $dynamicAttribute->attribute_id,
                     'attribute_type' => $dynamicAttribute->attribute_type
-                ]
-            );
+                ]);
     }
 
-    public function testViewAllEndpoint()
+    public function testViewAll()
     {
         for ($i = 0; $i < 52; $i++) {
             factory(DynamicAttribute::class)->create();
         }
         $dynamicAttributes = DynamicAttribute::all();
 
-        $this->get('/admin/api/dynamic-attribute')
-            ->assertStatus(302);
+        $this->get('/admin/api/dynamic-attribute')->assertStatus(302);
 
-        $response = $this->actingAs($this->user, 'api')
-            ->json('GET', '/admin/api/dynamic-attribute?page=1')
-            ->assertStatus(200)
-            ->assertJson([
+        $response = $this->actingAs($this->user, 'api')->json('GET',
+                '/admin/api/dynamic-attribute?page=1')->assertStatus(200)->assertJson([
                 'data' => [
-                    $dynamicAttributes[0]->toArray(),
-                    $dynamicAttributes[1]->toArray(),
+                    $dynamicAttributes[0]->toArray(), $dynamicAttributes[1]->toArray(),
                     $dynamicAttributes[2]->toArray(),
                 ],
-            ])
-            ->getData();
+            ])->getData();
 
         $this->assertEquals(count($response->data), 50);
 
-        $response = $this->actingAs($this->user, 'api')
-            ->json('GET', '/admin/api/dynamic-attribute?page=2')
-            ->assertStatus(200)
-            ->getData();
+        $response = $this->actingAs($this->user, 'api')->json('GET',
+                '/admin/api/dynamic-attribute?page=2')->assertStatus(200)->getData();
 
         $this->assertEquals(count($response->data), 2);
     }
 
-    public function testUpdateEndpoint()
+    public function testUpdateValidData()
     {
-        /* A complete update */
-        $a = factory(DynamicAttribute::class)->create();
-        $goodData = [
-            'attribute_id' => 'updated_id_a',
-            'attribute_type' => 'attribute.core.string'
+        $dynamicAttribute = factory(DynamicAttribute::class)->create();
+        $data = [
+            'attribute_id' => 'updated_id', 'attribute_type' => 'attribute.core.string'
         ];
-        $this->actingAs($this->user, 'api')
-            ->json('PATCH', '/admin/api/dynamic-attribute/' . $a->id, $goodData)
-            ->assertStatus(204);
-        $updatedDynamicAttribute = DynamicAttribute::find($a->id);
+        $this->actingAs($this->user, 'api')->json('PATCH', '/admin/api/dynamic-attribute/'.$dynamicAttribute->id,
+                $data)->assertNoContent(204);
+        $updatedDynamicAttribute = DynamicAttribute::find($dynamicAttribute->id);
 
-        $this->assertEquals($updatedDynamicAttribute->attribute_id, $goodData['attribute_id']);
-        $this->assertEquals($updatedDynamicAttribute->attribute_type, $goodData['attribute_type']);
+        $this->assertEquals($updatedDynamicAttribute->attribute_id, $data['attribute_id']);
+        $this->assertEquals($updatedDynamicAttribute->attribute_type, $data['attribute_type']);
+    }
 
-
-        /* A partial update (id only) */
-        $b = factory(DynamicAttribute::class)->create();
+    public function testUpdateIdOnly()
+    {
+        $dynamicAttribute = factory(DynamicAttribute::class)->create();
         $idOnly = [
-            'attribute_id' => 'updated_id_b',
+            'attribute_id' => 'updated_id',
         ];
-        $this->actingAs($this->user, 'api')
-            ->json('PATCH', '/admin/api/dynamic-attribute/' . $b->id, $idOnly)
-            ->assertStatus(204);
-        $updatedDynamicAttribute = DynamicAttribute::find($b->id);
+        $this->actingAs($this->user, 'api')->json('PATCH', '/admin/api/dynamic-attribute/'.$dynamicAttribute->id,
+                $idOnly)->assertStatus(204);
+        $updatedDynamicAttribute = DynamicAttribute::find($dynamicAttribute->id);
 
         $this->assertEquals($updatedDynamicAttribute->attribute_id, $idOnly['attribute_id']);
-        $this->assertEquals($updatedDynamicAttribute->attribute_type, $b->attribute_type);
+        $this->assertEquals($updatedDynamicAttribute->attribute_type, $dynamicAttribute->attribute_type);
 
 
-        /* A partial update (type only) */
-        $c = factory(DynamicAttribute::class)->create();
+    }
+
+    public function testUpdateTypeOnly()
+    {
+        $dynamicAttribute = factory(DynamicAttribute::class)->create();
         $typeOnly = [
             'attribute_type' => 'attribute.core.int'
         ];
-        $this->actingAs($this->user, 'api')
-            ->json('PATCH', '/admin/api/dynamic-attribute/' . $c->id, $typeOnly)
-            ->assertStatus(204);
-        $updatedDynamicAttribute = DynamicAttribute::find($c->id);
+        $this->actingAs($this->user, 'api')->json('PATCH', '/admin/api/dynamic-attribute/'.$dynamicAttribute->id,
+                $typeOnly)->assertStatus(204);
+        $updatedDynamicAttribute = DynamicAttribute::find($dynamicAttribute->id);
 
-        $this->assertEquals($updatedDynamicAttribute->attribute_id, $c->attribute_id);
+        $this->assertEquals($updatedDynamicAttribute->attribute_id, $dynamicAttribute->attribute_id);
         $this->assertEquals($updatedDynamicAttribute->attribute_type, $typeOnly['attribute_type']);
+    }
 
-
-        /* Bad update (Duplicate attribute_id) */
-        $d = factory(DynamicAttribute::class)->create();
-        $e = factory(DynamicAttribute::class)->create();
-        $duplicateId = [
-            'attribute_id' => $e->attribute_id
+    public function testUpdateDuplicateId()
+    {
+        $a = factory(DynamicAttribute::class)->create();
+        $b = factory(DynamicAttribute::class)->create();
+        $data = [
+            'attribute_id' => $b->attribute_id
         ];
-        $this->actingAs($this->user, 'api')
-            ->json('PATCH', '/admin/api/dynamic-attribute/' . $d->id, $duplicateId)
-            ->assertStatus(400);
+        $this->actingAs($this->user, 'api')->json('PATCH', '/admin/api/dynamic-attribute/'.$a->id,
+                $data)->assertStatus(400)->assertJson([
+                'field' => 'attribute_id',
+                'message' => sprintf("Attribute id '%s' is already in use.", $b->attribute_id)
+            ]);
+    }
 
-        /* Bad Updates (Invalid attribute_ids) */
-        $f = factory(DynamicAttribute::class)->create();
+    public function testUpdateInvalidIdFormat()
+    {
+        $dynamicAttribute = factory(DynamicAttribute::class)->create();
         foreach (self::invalidIds as $invalidId) {
             $data = [
                 'attribute_id' => $invalidId
             ];
-            $this->actingAs($this->user, 'api')
-                ->json('PATCH', '/admin/api/dynamic-attribute/' . $f->id, $data)
-                ->assertStatus(400);
+            $this->actingAs($this->user, 'api')->json('PATCH', '/admin/api/dynamic-attribute/'.$dynamicAttribute->id,
+                    $data)->assertStatus(400)->assertJson([
+                    'field' => 'attribute_id', 'message' => 'attribute_id field must follow snake_case format.',
+                ]);
         }
+    }
 
-        /* Bad Updates (Invalid attribute_types) */
-        $g = factory(DynamicAttribute::class)->create();
+    public function testUpdateInvalidTypeFormat()
+    {
+        $dynamicAttribute = factory(DynamicAttribute::class)->create();
         foreach (self::invalidTypes as $invalidType) {
             $data = [
                 'attribute_type' => $invalidType
             ];
-            $this->actingAs($this->user, 'api')
-                ->json('PATCH', '/admin/api/dynamic-attribute/' . $g->id, $data)
-                ->assertStatus(400);
+            $this->actingAs($this->user, 'api')->json('PATCH', '/admin/api/dynamic-attribute/'.$dynamicAttribute->id,
+                    $data)->assertStatus(400)->assertJson([
+                    'field' => 'attribute_type',
+                    'message' => "attribute_type field must follow the format: 'attribute.<component_name>.<type>'",
+                ]);
         }
-
-
     }
 
-    public function testStoreEndpoint()
-    {
-        /* Successful */
-        $goodData = [
-            'attribute_id' => 'test_dynamic_attribute_a',
-            'attribute_type' => 'attribute.core.string'
-        ];
-        $this->actingAs($this->user, 'api')
-            ->json('POST', '/admin/api/dynamic-attribute', $goodData)
-            ->assertStatus(201)
-            ->assertJsonFragment($goodData);
+//    public function testUpdateUnregisteredType()
+//    {
+//        $dynamicAttribute = factory(DynamicAttribute::class)->create();
+//        $data = [
+//            'attribute_type' => 'attribute.core.unregistered_attribute_type'
+//        ];
+//        $this->actingAs($this->user, 'api')->json('PATCH', '/admin/api/dynamic-attribute/'.$dynamicAttribute->id,
+//                $data)->assertStatus(400)->assertJson([
+//                'field' => 'attribute_type',
+//                'message' => sprintf('attribute_type %s is not registered.', $data['attribute_type'])
+//            ]);
+//    }
 
-        /* Missing attribute_id */
-        $missingId = [
+
+    public function testStoreValidData()
+    {
+        $data = [
+            'attribute_id' => 'test_dynamic_attribute', 'attribute_type' => 'attribute.core.string'
+        ];
+        $this->actingAs($this->user, 'api')->json('POST', '/admin/api/dynamic-attribute',
+                $data)->assertStatus(201)->assertJsonFragment($data);
+        $this->assertDatabaseHas('dynamic_attributes', $data);
+    }
+
+    public function testStoreMissingAttributeId()
+    {
+        $data = [
             'attribute_type' => 'attribute.core.string',
         ];
-        $this->actingAs($this->user, 'api')
-            ->json('POST', '/admin/api/dynamic-attribute', $missingId)
-            ->assertStatus(400)
-            ->assertJsonFragment(
-                [
-                    'field' => 'attribute_id',
-                    'message' => 'attribute_id field is required.',
-                ]
-            );
+        $this->actingAs($this->user, 'api')->json('POST', '/admin/api/dynamic-attribute',
+                $data)->assertStatus(400)->assertJsonFragment([
+                    'field' => 'attribute_id', 'message' => 'attribute_id field is required.',
+                ]);
+        $this->assertDatabaseMissing('dynamic_attributes', []);
+    }
 
-        /* Missing attribute_type */
-        $missingType = [
-            'attribute_id' => 'test_dynamic_attribute_b'
+    public function testStoreMissingType()
+    {
+        $data = [
+            'attribute_id' => 'test_dynamic_attribute'
         ];
-        $this->actingAs($this->user, 'api')
-            ->json('POST', '/admin/api/dynamic-attribute', $missingType)
-            ->assertStatus(400)
-            ->assertJsonFragment(
-                [
-                    'field' => 'attribute_type',
-                    'message' => 'attribute_type field is required.',
-                ]
-            );
+        $this->actingAs($this->user, 'api')->json('POST', '/admin/api/dynamic-attribute',
+                $data)->assertStatus(400)->assertJsonFragment([
+                    'field' => 'attribute_type', 'message' => 'attribute_type field is required.',
+                ]);
+        $this->assertDatabaseMissing('dynamic_attributes', []);
+    }
 
-
-        /* Invalid attribute ids (wrong format) */
-        $invalidIdFormats = array_map(fn($id) => ['attribute_id' => $id, 'attribute_type' => 'attribute.core.string'], self::invalidIds);
-        foreach ($invalidIdFormats as $invalidIdFormat) {
-            $this->actingAs($this->user, 'api')
-                ->json('POST', '/admin/api/dynamic-attribute', $invalidIdFormat)
-                ->assertStatus(400)
-                ->assertJsonFragment(
-                    [
-                        'field' => 'attribute_id',
-                        'message' => 'attribute_id field must follow snake_case format.',
-                    ]
-                );
-        }
-
-        /* Invalid attribute types (wrong format) */
-        $invalidTypeFormats = array_map(fn($type) => ['attribute_id' => 'attribute_id', 'attribute_type' => $type], self::invalidIds);
-        foreach ($invalidTypeFormats as $invalidTypeFormat) {
-            $this->actingAs($this->user, 'api')
-                ->json('POST', '/admin/api/dynamic-attribute', $invalidTypeFormat)
-                ->assertStatus(400)
-                ->assertJsonFragment(
-                    [
-                        'field' => 'attribute_type',
-                        'message' => "attribute_type field must follow the format: 'attribute.<component_name>.<type>'",
-                    ]
-                );
+    public function testStoreInvalidIdFormat()
+    {
+        foreach (self::invalidIds as $id) {
+            $data = [
+                'attribute_id' => $id, 'attribute_type' => 'attribute.core.string'
+            ];
+            $this->actingAs($this->user, 'api')->json('POST', '/admin/api/dynamic-attribute',
+                    $data)->assertStatus(400)->assertJsonFragment([
+                        'field' => 'attribute_id', 'message' => 'attribute_id field must follow snake_case format.',
+                    ]);
+            $this->assertDatabaseMissing('dynamic_attributes', $data);
         }
     }
 
-    public function testDestroyEndpoint()
+    public function testStoreInvalidTypeFormat()
+    {
+        foreach (self::invalidTypes as $type) {
+            $data = [
+                'attribute_id' => 'test_dynamic_attribute', 'attribute_type' => $type
+            ];
+            $this->actingAs($this->user, 'api')->json('POST', '/admin/api/dynamic-attribute',
+                    $data)->assertStatus(400)->assertJsonFragment([
+                        'field' => 'attribute_type',
+                        'message' => "attribute_type field must follow the format: 'attribute.<component_name>.<type>'",
+                    ]);
+            $this->assertDatabaseMissing('dynamic_attributes', $data);
+        }
+    }
+
+//    public function testStoreUnregisteredType()
+//    {
+//        $dynamicAttribute = factory(DynamicAttribute::class)->create();
+//        $data = [
+//            'attribute_id' => 'test_dynamic_attribute', 'attribute_type' => 'attribute.core.unregistered_attribute_type'
+//        ];
+//        $this->actingAs($this->user, 'api')->json('PATCH', '/admin/api/dynamic-attribute/'.$dynamicAttribute->id,
+//                $data)->assertStatus(400)->assertJson([
+//                'field' => 'attribute_type',
+//                'message' => sprintf('attribute_type %s is not registered.', $data['attribute_type'])
+//            ]);
+//        $this->assertDatabaseMissing('dynamic_attributes', $data);
+//    }
+
+    public function testDestroy()
     {
         $dynamicAttribute = factory(DynamicAttribute::class)->create();
 
-        $this->actingAs($this->user, 'api')
-            ->json('DELETE', '/admin/api/dynamic-attribute/' . $dynamicAttribute->id)
-            ->assertStatus(204);
+        $this->actingAs($this->user, 'api')->json('DELETE',
+                '/admin/api/dynamic-attribute/'.$dynamicAttribute->id)->assertStatus(204);
 
         $this->assertEquals(DynamicAttribute::find($dynamicAttribute->id), null);
     }
 
 
-    public function testDownloadEndpoint()
+    public function testDownload()
     {
         for ($i = 0; $i < 52; $i++) {
             factory(DynamicAttribute::class)->create();
@@ -251,55 +274,120 @@ class DynamicAttributesTest extends TestCase
             $expected[$datum->attribute_id] = $datum->attribute_type;
         }
 
-        $this->actingAs($this->user, 'api')->get('/admin/api/dynamic-attributes/download')->assertStatus(200)->assertJson($expected);
-
+        $this->actingAs($this->user,
+            'api')->get('/admin/api/dynamic-attributes/download')->assertStatus(200)->assertJson($expected);
     }
 
-    public function testUploadEndpoint()
+    public function testUploadNoAuth()
     {
-        /* No user for auth. Should redirect */
-        $goodData = [
-            'dynamic_attributes_test_a' => 'attribute.core.string',
-            'dynamic_attributes_test_b' => 'attribute.core.int',
+        $data = [
+            'dynamic_attributes_test_a' => 'attribute.core.string', 'dynamic_attributes_test_b' => 'attribute.core.int',
             'dynamic_attributes_test_c' => 'attribute.core.err'
         ];
-        $this->post('/admin/api/dynamic-attributes/upload', $goodData)->assertStatus(302);
+        $this->post('/admin/api/dynamic-attributes/upload', $data)->assertStatus(302);
+    }
 
-        /* A good upload */
-        $this->actingAs($this->user, 'api')->post('/admin/api/dynamic-attributes/upload', $goodData)->assertStatus(201)->assertJson($goodData);
-        foreach ($goodData as $id => $type) {
+    public function testUploadValidData()
+    {
+        $data = [
+            'dynamic_attributes_test_a' => 'attribute.core.string', 'dynamic_attributes_test_b' => 'attribute.core.int',
+            'dynamic_attributes_test_c' => 'attribute.core.err'
+        ];
+        $this->actingAs($this->user, 'api')->post('/admin/api/dynamic-attributes/upload',
+            $data)->assertStatus(201)->assertJson($data);
+        foreach ($data as $id => $type) {
             $this->assertDatabaseHas('dynamic_attributes', ['attribute_id' => $id, 'attribute_type' => $type]);
         }
-
-        /* Uploading duplicate data should fail */
-        $this->actingAs($this->user, 'api')->post('/admin/api/dynamic-attributes/upload', $goodData)->assertStatus(400);
-
-        /* Uploading nothing should fail */
-        $noData = [];
-        $this->actingAs($this->user, 'api')->post('/admin/api/dynamic-attributes/upload', $noData)->assertStatus(400);
-
-        /* Uploading with bad Id should fail */
-        foreach (self::invalidIds as $id) {
-            $data = [
-                $id => 'attribute.core.int'
-            ];
-            $this->actingAs($this->user, 'api')->post('/admin/api/dynamic-attributes/upload', $data)->assertStatus(400);
-        }
-
-        /* Uploading with bad type data should fail */
-        foreach (self::invalidTypes as $type) {
-            $data = [
-                'dynamic_attributes_test' => $type
-            ];
-            $this->actingAs($this->user, 'api')->post('/admin/api/dynamic-attributes/upload', $data)->assertStatus(400);
-        }
-
-        $duplicateConfigID = [
-            //TODO: Upload ID overwriting config ID
-        ];
-
-        $nonExistantType = [
-            //TODO: Upload non-existant type
-        ];
     }
+
+    public function testUploadDuplicateId()
+    {
+        $data = [
+            'dynamic_attributes_test_a' => 'attribute.core.string', 'dynamic_attributes_test_b' => 'attribute.core.int',
+            'dynamic_attributes_test_c' => 'attribute.core.err'
+        ];
+        foreach ($data as $attribute_id => $attribute_type) {
+            DynamicAttribute::create(['attribute_id' => $attribute_id, 'attribute_type' => $attribute_type]);
+        }
+
+        $this->actingAs($this->user, 'api')->post('/admin/api/dynamic-attributes/upload',
+            $data)->assertStatus(400)->assertJson([
+                'ids' => array_keys($data), 'message' => 'Some ids are already in use.',
+            ]);
+
+    }
+
+    public function testUploadEmptyData()
+    {
+        $noData = [];
+        $this->actingAs($this->user, 'api')->post('/admin/api/dynamic-attributes/upload',
+            $noData)->assertStatus(400)->assertJson(
+
+            [
+                'message' => 'The provided JSON contains no properties. You must provide JSON object of the form:
+ { <attribute_id>: attribute.<component>.<attribute_type>, ... }'
+            ]);
+    }
+
+    public function testUploadInvalidIdFormats()
+    {
+        $data = array_fill_keys(self::invalidIds, 'attribute.core.string');
+
+        $this->actingAs($this->user, 'api')->post('/admin/api/dynamic-attributes/upload',
+            $data)->assertStatus(400)->assertJson([
+            'ids' => self::invalidIds, 'message' => 'Invalid attribute ids. All attribute Ids must be in snake_case',
+        ]);
+        foreach (self::invalidIds as $id) {
+            $this->assertDatabaseMissing('dynamic_attributes',
+                ['attribute_id' => $id, 'attribute_type' => 'attribute.core.string']);
+        }
+    }
+
+    public function testUploadInvalidTypeFormats()
+    {
+        $ids = array_map(fn(
+        ) => $this->faker->unique()->regexify(\OpenDialogAi\ContextEngine\AttributeResolver\AttributeResolver::$validIdPattern),
+            array_keys(self::invalidTypes));
+        $data = array_combine($ids, self::invalidTypes);
+
+        $this->actingAs($this->user, 'api')->post('/admin/api/dynamic-attributes/upload',
+            $data)->assertStatus(400)->assertJson([
+            'types' => self::invalidTypes, 'message' => 'Invalid attribute types. All attribute types must be in the following format:
+ attribute.<component>.<type>',
+        ]);
+        foreach ($data as $attribute_id => $attribute_type) {
+            $this->assertDatabaseMissing('dynamic_attributes',
+                ['attribute_id' => $attribute_id, 'attribute_type' => $attribute_type]);
+        }
+    }
+
+//    public function testUploadDuplicateCoreIds()
+//    {
+//
+//        $ids = array_slice(array_keys(AttributeResolver::getSupportedAttributes()), 0, 3);
+//
+//        $data = array_fill_keys($ids, 'attribute.core.int');
+//        $this->actingAs($this->user, 'api')->post('/admin/api/dynamic-attributes/upload',
+//            $data)->assertStatus(400)->assertJson([
+//            'ids' => $ids, 'message' => 'Some ids are already in use.',
+//
+//        ]);
+//        foreach ($data as $attribute_id => $attribute_type) {
+//            $this->assertDatabaseMissing('dynamic_attributes',
+//                ['attribute_id' => $attribute_id, 'attribute_type' => $attribute_type]);
+//        }
+//    }
+
+//    public function testUploadUnregisteredType()
+//    {
+//        $data = [
+//            'dynamic_attributes_test' => 'attribute.core.non_existant',
+//        ];
+//        $this->actingAs($this->user, 'api')->post('/admin/api/dynamic-attributes/upload',
+//            $data)->assertStatus(400)->assertJson([
+//            'types' => ['attribute.core.non_existant'], 'message' => 'Some types are not registered'
+//        ]);
+//        $this->assertDatabaseMissing('dynamic_attributes',
+//            ['attribute_id' => 'dynamic_attributes_test', 'attribute_type' => 'attribute.core.non_existant']);
+//    }
 }

--- a/tests/Feature/DynamicAttributesTest.php
+++ b/tests/Feature/DynamicAttributesTest.php
@@ -1,0 +1,305 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\User;
+use OpenDialogAi\Core\DynamicAttribute;
+use Tests\TestCase;
+
+/**
+ * Class DynamicAttributesTest
+ * @package Tests\Feature
+ * @group SpecificationTests
+ */
+class DynamicAttributesTest extends TestCase
+{
+    const invalidIds = ['testDynamicAttribute', 'test_Dynamic.Attribute', 'test_dynamic_attribute_1', 'test_Dynamic.Attribute_1', 'testdynamicattribute1'];
+    const invalidTypes = ['attributeCoreString', 'attribute.string', 'core.string', 'string', 'wrong.core.string'];
+    protected $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = factory(User::class)->create();
+
+        DynamicAttribute::truncate();
+
+    }
+
+    public function testViewEndpoint()
+    {
+        $dynamicAttribute = factory(DynamicAttribute::class)->create();
+
+        $this->get('/admin/api/dynamic-attribute/' . $dynamicAttribute->id)
+            ->assertStatus(302);
+
+        $this->actingAs($this->user, 'api')
+            ->json('GET', '/admin/api/dynamic-attribute/' . $dynamicAttribute->id)
+            ->assertStatus(200)
+            ->assertJsonFragment(
+                [
+                    'attribute_id' => $dynamicAttribute->attribute_id,
+                    'attribute_type' => $dynamicAttribute->attribute_type
+                ]
+            );
+    }
+
+    public function testViewAllEndpoint()
+    {
+        for ($i = 0; $i < 52; $i++) {
+            factory(DynamicAttribute::class)->create();
+        }
+        $dynamicAttributes = DynamicAttribute::all();
+
+        $this->get('/admin/api/dynamic-attribute')
+            ->assertStatus(302);
+
+        $response = $this->actingAs($this->user, 'api')
+            ->json('GET', '/admin/api/dynamic-attribute?page=1')
+            ->assertStatus(200)
+            ->assertJson([
+                'data' => [
+                    $dynamicAttributes[0]->toArray(),
+                    $dynamicAttributes[1]->toArray(),
+                    $dynamicAttributes[2]->toArray(),
+                ],
+            ])
+            ->getData();
+
+        $this->assertEquals(count($response->data), 50);
+
+        $response = $this->actingAs($this->user, 'api')
+            ->json('GET', '/admin/api/dynamic-attribute?page=2')
+            ->assertStatus(200)
+            ->getData();
+
+        $this->assertEquals(count($response->data), 2);
+    }
+
+    public function testUpdateEndpoint()
+    {
+        /* A complete update */
+        $a = factory(DynamicAttribute::class)->create();
+        $goodData = [
+            'attribute_id' => 'updated_id_a',
+            'attribute_type' => 'attribute.core.string'
+        ];
+        $this->actingAs($this->user, 'api')
+            ->json('PATCH', '/admin/api/dynamic-attribute/' . $a->id, $goodData)
+            ->assertStatus(204);
+        $updatedDynamicAttribute = DynamicAttribute::find($a->id);
+
+        $this->assertEquals($updatedDynamicAttribute->attribute_id, $goodData['attribute_id']);
+        $this->assertEquals($updatedDynamicAttribute->attribute_type, $goodData['attribute_type']);
+
+
+        /* A partial update (id only) */
+        $b = factory(DynamicAttribute::class)->create();
+        $idOnly = [
+            'attribute_id' => 'updated_id_b',
+        ];
+        $this->actingAs($this->user, 'api')
+            ->json('PATCH', '/admin/api/dynamic-attribute/' . $b->id, $idOnly)
+            ->assertStatus(204);
+        $updatedDynamicAttribute = DynamicAttribute::find($b->id);
+
+        $this->assertEquals($updatedDynamicAttribute->attribute_id, $idOnly['attribute_id']);
+        $this->assertEquals($updatedDynamicAttribute->attribute_type, $b->attribute_type);
+
+
+        /* A partial update (type only) */
+        $c = factory(DynamicAttribute::class)->create();
+        $typeOnly = [
+            'attribute_type' => 'attribute.core.int'
+        ];
+        $this->actingAs($this->user, 'api')
+            ->json('PATCH', '/admin/api/dynamic-attribute/' . $c->id, $typeOnly)
+            ->assertStatus(204);
+        $updatedDynamicAttribute = DynamicAttribute::find($c->id);
+
+        $this->assertEquals($updatedDynamicAttribute->attribute_id, $c->attribute_id);
+        $this->assertEquals($updatedDynamicAttribute->attribute_type, $typeOnly['attribute_type']);
+
+
+        /* Bad update (Duplicate attribute_id) */
+        $d = factory(DynamicAttribute::class)->create();
+        $e = factory(DynamicAttribute::class)->create();
+        $duplicateId = [
+            'attribute_id' => $e->attribute_id
+        ];
+        $this->actingAs($this->user, 'api')
+            ->json('PATCH', '/admin/api/dynamic-attribute/' . $d->id, $duplicateId)
+            ->assertStatus(400);
+
+        /* Bad Updates (Invalid attribute_ids) */
+        $f = factory(DynamicAttribute::class)->create();
+        foreach (self::invalidIds as $invalidId) {
+            $data = [
+                'attribute_id' => $invalidId
+            ];
+            $this->actingAs($this->user, 'api')
+                ->json('PATCH', '/admin/api/dynamic-attribute/' . $f->id, $data)
+                ->assertStatus(400);
+        }
+
+        /* Bad Updates (Invalid attribute_types) */
+        $g = factory(DynamicAttribute::class)->create();
+        foreach (self::invalidTypes as $invalidType) {
+            $data = [
+                'attribute_type' => $invalidType
+            ];
+            $this->actingAs($this->user, 'api')
+                ->json('PATCH', '/admin/api/dynamic-attribute/' . $g->id, $data)
+                ->assertStatus(400);
+        }
+
+
+    }
+
+    public function testStoreEndpoint()
+    {
+        /* Successful */
+        $goodData = [
+            'attribute_id' => 'test_dynamic_attribute_a',
+            'attribute_type' => 'attribute.core.string'
+        ];
+        $this->actingAs($this->user, 'api')
+            ->json('POST', '/admin/api/dynamic-attribute', $goodData)
+            ->assertStatus(201)
+            ->assertJsonFragment($goodData);
+
+        /* Missing attribute_id */
+        $missingId = [
+            'attribute_type' => 'attribute.core.string',
+        ];
+        $this->actingAs($this->user, 'api')
+            ->json('POST', '/admin/api/dynamic-attribute', $missingId)
+            ->assertStatus(400)
+            ->assertJsonFragment(
+                [
+                    'field' => 'attribute_id',
+                    'message' => 'attribute_id field is required.',
+                ]
+            );
+
+        /* Missing attribute_type */
+        $missingType = [
+            'attribute_id' => 'test_dynamic_attribute_b'
+        ];
+        $this->actingAs($this->user, 'api')
+            ->json('POST', '/admin/api/dynamic-attribute', $missingType)
+            ->assertStatus(400)
+            ->assertJsonFragment(
+                [
+                    'field' => 'attribute_type',
+                    'message' => 'attribute_type field is required.',
+                ]
+            );
+
+
+        /* Invalid attribute ids (wrong format) */
+        $invalidIdFormats = array_map(fn($id) => ['attribute_id' => $id, 'attribute_type' => 'attribute.core.string'], self::invalidIds);
+        foreach ($invalidIdFormats as $invalidIdFormat) {
+            $this->actingAs($this->user, 'api')
+                ->json('POST', '/admin/api/dynamic-attribute', $invalidIdFormat)
+                ->assertStatus(400)
+                ->assertJsonFragment(
+                    [
+                        'field' => 'attribute_id',
+                        'message' => 'attribute_id field must follow snake_case format.',
+                    ]
+                );
+        }
+
+        /* Invalid attribute types (wrong format) */
+        $invalidTypeFormats = array_map(fn($type) => ['attribute_id' => 'attribute_id', 'attribute_type' => $type], self::invalidIds);
+        foreach ($invalidTypeFormats as $invalidTypeFormat) {
+            $this->actingAs($this->user, 'api')
+                ->json('POST', '/admin/api/dynamic-attribute', $invalidTypeFormat)
+                ->assertStatus(400)
+                ->assertJsonFragment(
+                    [
+                        'field' => 'attribute_type',
+                        'message' => "attribute_type field must follow the format: 'attribute.<component_name>.<type>'",
+                    ]
+                );
+        }
+    }
+
+    public function testDestroyEndpoint()
+    {
+        $dynamicAttribute = factory(DynamicAttribute::class)->create();
+
+        $this->actingAs($this->user, 'api')
+            ->json('DELETE', '/admin/api/dynamic-attribute/' . $dynamicAttribute->id)
+            ->assertStatus(204);
+
+        $this->assertEquals(DynamicAttribute::find($dynamicAttribute->id), null);
+    }
+
+
+    public function testDownloadEndpoint()
+    {
+        for ($i = 0; $i < 52; $i++) {
+            factory(DynamicAttribute::class)->create();
+        }
+        $data = DynamicAttribute::all();
+
+        $expected = [];
+        foreach ($data as $datum) {
+            $expected[$datum->attribute_id] = $datum->attribute_type;
+        }
+
+        $this->actingAs($this->user, 'api')->get('/admin/api/dynamic-attributes/download')->assertStatus(200)->assertJson($expected);
+
+    }
+
+    public function testUploadEndpoint()
+    {
+        /* No user for auth. Should redirect */
+        $goodData = [
+            'dynamic_attributes_test_a' => 'attribute.core.string',
+            'dynamic_attributes_test_b' => 'attribute.core.int',
+            'dynamic_attributes_test_c' => 'attribute.core.err'
+        ];
+        $this->post('/admin/api/dynamic-attributes/upload', $goodData)->assertStatus(302);
+
+        /* A good upload */
+        $this->actingAs($this->user, 'api')->post('/admin/api/dynamic-attributes/upload', $goodData)->assertStatus(201)->assertJson($goodData);
+        foreach ($goodData as $id => $type) {
+            $this->assertDatabaseHas('dynamic_attributes', ['attribute_id' => $id, 'attribute_type' => $type]);
+        }
+
+        /* Uploading duplicate data should fail */
+        $this->actingAs($this->user, 'api')->post('/admin/api/dynamic-attributes/upload', $goodData)->assertStatus(400);
+
+        /* Uploading nothing should fail */
+        $noData = [];
+        $this->actingAs($this->user, 'api')->post('/admin/api/dynamic-attributes/upload', $noData)->assertStatus(400);
+
+        /* Uploading with bad Id should fail */
+        foreach (self::invalidIds as $id) {
+            $data = [
+                $id => 'attribute.core.int'
+            ];
+            $this->actingAs($this->user, 'api')->post('/admin/api/dynamic-attributes/upload', $data)->assertStatus(400);
+        }
+
+        /* Uploading with bad type data should fail */
+        foreach (self::invalidTypes as $type) {
+            $data = [
+                'dynamic_attributes_test' => $type
+            ];
+            $this->actingAs($this->user, 'api')->post('/admin/api/dynamic-attributes/upload', $data)->assertStatus(400);
+        }
+
+        $duplicateConfigID = [
+            //TODO: Upload ID overwriting config ID
+        ];
+
+        $nonExistantType = [
+            //TODO: Upload non-existant type
+        ];
+    }
+}

--- a/tests/Feature/ImportExportConversationsTest.php
+++ b/tests/Feature/ImportExportConversationsTest.php
@@ -10,6 +10,7 @@ use OpenDialogAi\Core\Graph\DGraph\DGraphClient;
 
 /**
  * Class ImportExportConversationsTest
+ *
  * @package Tests\Feature
  * @group SpecificationTests
  */
@@ -19,51 +20,34 @@ class ImportExportConversationsTest extends BaseSpecificationTest
     {
         $this->assertDatabaseMissing('conversations', ['name' => 'no_match_conversation']);
 
-        $this->assertEmpty(
-            resolve(DGraphClient::class)
-                ->query(DGraphConversationQueryFactory::getConversationTemplateIds())
-                ->getData()
-        );
+        $this->assertEmpty(resolve(DGraphClient::class)->query(DGraphConversationQueryFactory::getConversationTemplateIds())->getData());
 
-        Artisan::call(
-            'conversations:import',
-            [
-                '--yes' => true,
-                '--activate' => true,
-            ]
-        );
+        Artisan::call('conversations:import', [
+            '--yes' => true, '--activate' => true,
+        ]);
 
         $this->assertDatabaseHas('conversations', ['name' => 'no_match_conversation']);
 
-        $this->assertCount(
-            2,
-            resolve(DGraphClient::class)
-                ->query(DGraphConversationQueryFactory::getConversationTemplateIds())
-                ->getData()
-        );
+        $this->assertCount(2,
+            resolve(DGraphClient::class)->query(DGraphConversationQueryFactory::getConversationTemplateIds())->getData());
     }
 
     public function testExportConversations()
     {
-        Artisan::call(
-            'conversations:import',
-            [
-                '--yes' => true
-            ]
-        );
+        Artisan::call('conversations:import', [
+            '--yes' => true
+        ]);
 
         $this->assertDatabaseHas('conversations', ['name' => 'no_match_conversation']);
 
         $conversation = Conversation::where('name', 'no_match_conversation')->first();
-        $conversation->model = str_replace('intent.core.NoMatchResponse', 'intent.core.NoMatchResponse2', $conversation->model);
+        $conversation->model = str_replace('intent.core.NoMatchResponse', 'intent.core.NoMatchResponse2',
+            $conversation->model);
         $conversation->save();
 
-        Artisan::call(
-            'conversations:export',
-            [
-                '--yes' => true
-            ]
-        );
+        Artisan::call('conversations:export', [
+            '--yes' => true
+        ]);
 
         $conversationFileName = ConversationImportExportHelper::addConversationFileExtension($conversation->name);
         $filename = ConversationImportExportHelper::getConversationPath($conversationFileName);
@@ -73,12 +57,9 @@ class ImportExportConversationsTest extends BaseSpecificationTest
 
     public function testUpdateConversations()
     {
-        Artisan::call(
-            'conversations:import',
-            [
-                '--yes' => true
-            ]
-        );
+        Artisan::call('conversations:import', [
+            '--yes' => true
+        ]);
 
         $this->assertDatabaseHas('conversations', ['name' => 'no_match_conversation']);
 
@@ -89,13 +70,9 @@ class ImportExportConversationsTest extends BaseSpecificationTest
         $filename = ConversationImportExportHelper::getConversationPath($conversationFileName);
         $this->disk->put($filename, $model);
 
-        Artisan::call(
-            'conversations:import',
-            [
-                '--yes' => true,
-                'conversation' => 'no_match_conversation'
-            ]
-        );
+        Artisan::call('conversations:import', [
+            '--yes' => true, 'conversation' => 'no_match_conversation'
+        ]);
 
         $conversation = Conversation::where('name', 'no_match_conversation')->first();
         $this->assertStringContainsString('intent.core.NoMatchResponse2', $conversation->model);

--- a/tests/Feature/ImportExportDynamicAttributesTest.php
+++ b/tests/Feature/ImportExportDynamicAttributesTest.php
@@ -10,6 +10,7 @@ use Tests\TestCase;
 
 /**
  * Class ImportExportIntentsTest
+ *
  * @package Tests\Feature
  * @group SpecificationTests
  */
@@ -25,7 +26,6 @@ class ImportExportDynamicAttributesTest extends TestCase
     {
         parent::setUp();
 
-        DynamicAttribute::truncate();
         $this->disk = Storage::fake('specification');
     }
 
@@ -38,34 +38,31 @@ class ImportExportDynamicAttributesTest extends TestCase
 
         $this->disk->put(DynamicAttributeImportExportHelper::getFilePath('good-custom-attributes'), $notJSON);
 
-        Artisan::call(
-            'dynamic-attributes:import',
-            [
-                '--yes' => true,
-                'name' => 'good-custom-attributes'
-            ]
-        );
+        Artisan::call('dynamic-attributes:import', [
+                '--yes' => true, 'name' => 'good-custom-attributes'
+        ]);
 
-        $this->assertDatabaseMissing('dynamic_attributes', ['attribute_id' => "test_dynamic_attribute_a", 'attribute_type' => "attribute.core.string"]);
-        $this->assertDatabaseMissing('dynamic_attributes', ['attribute_id' => "test_dynamic_attribute_b", 'attribute_type' => "attribute.core.int"]);
+
+        $this->assertDatabaseMissing('dynamic_attributes',
+            ['attribute_id' => "test_dynamic_attribute_a", 'attribute_type' => "attribute.core.string"]);
+        $this->assertDatabaseMissing('dynamic_attributes',
+            ['attribute_id' => "test_dynamic_attribute_b", 'attribute_type' => "attribute.core.int"]);
 
     }
 
     public function testImportInvalidAttributeIds()
     {
-
         foreach (DynamicAttributesTest::invalidIds as $id) {
             $data = [$id => 'attribute.core.string'];
-            $this->disk->put(DynamicAttributeImportExportHelper::getFilePath('invalid-ids-attributes'), json_encode($data));
+            $this->disk->put(DynamicAttributeImportExportHelper::getFilePath('invalid-ids-attributes'),
+                json_encode($data));
 
-            Artisan::call(
-                'dynamic-attributes:import',
-                [
-                    '--yes' => true,
-                    'name' => 'invalid-ids-attributes'
-                ]
-            );
-            $this->assertDatabaseMissing('dynamic_attributes', ['attribute_id' => $id, 'attribute_type' => "attribute.core.string"]);
+            Artisan::call('dynamic-attributes:import', [
+                    '--yes' => true, 'name' => 'invalid-ids-attributes'
+                ]);
+
+            $this->assertDatabaseMissing('dynamic_attributes',
+                ['attribute_id' => $id, 'attribute_type' => "attribute.core.string"]);
 
         }
 
@@ -76,17 +73,15 @@ class ImportExportDynamicAttributesTest extends TestCase
 
         foreach (DynamicAttributesTest::invalidTypes as $type) {
             $data = ["dynamic_attribute_test" => $type];
-            $this->disk->put(DynamicAttributeImportExportHelper::getFilePath('invalid-types-attributes'), json_encode($data));
+            $this->disk->put(DynamicAttributeImportExportHelper::getFilePath('invalid-types-attributes'),
+                json_encode($data));
 
-            Artisan::call(
-                'dynamic-attributes:import',
-                [
-                    '--yes' => true,
-                    'name' => 'invalid-types-attributes'
-                ]
-            );
+            Artisan::call('dynamic-attributes:import', [
+                    '--yes' => true, 'name' => 'invalid-types-attributes'
+                ]);
 
-            $this->assertDatabaseMissing('dynamic_attributes', ['attribute_id' => "dynamic_attribute_test", 'attribute_type' => $type]);
+            $this->assertDatabaseMissing('dynamic_attributes',
+                ['attribute_id' => "dynamic_attribute_test", 'attribute_type' => $type]);
         }
 
     }
@@ -95,47 +90,40 @@ class ImportExportDynamicAttributesTest extends TestCase
     {
 
         $goodData = [
-            'test_dynamic_attribute_a' => 'attribute.core.string',
-            'test_dynamic_attribute_b' => 'attribute.core.int',
+            'test_dynamic_attribute_a' => 'attribute.core.string', 'test_dynamic_attribute_b' => 'attribute.core.int',
             'test_dynamic_attribute_c' => 'attribute.core.string'
         ];
 
-        $this->disk->put(DynamicAttributeImportExportHelper::getFilePath('good-custom-attributes'), json_encode($goodData));
+        $this->disk->put(DynamicAttributeImportExportHelper::getFilePath('good-custom-attributes'),
+            json_encode($goodData));
 
-        Artisan::call(
-            'dynamic-attributes:import',
-            [
-                '--yes' => true,
-                'name' => 'good-custom-attributes'
-            ]
-        );
+        Artisan::call('dynamic-attributes:import', [
+                '--yes' => true, 'name' => 'good-custom-attributes'
+            ]);
 
         foreach ($goodData as $attribute_id => $attribute_type) {
-            $this->assertDatabaseHas('dynamic_attributes', ['attribute_id' => $attribute_id, 'attribute_type' => $attribute_type]);
+            $this->assertDatabaseHas('dynamic_attributes',
+                ['attribute_id' => $attribute_id, 'attribute_type' => $attribute_type]);
         }
 
     }
 
     public function testExportSuccess()
     {
-        for ($i = 0; $i < 50; $i++) {
+        for ($i = 0; $i < 3; $i++) {
             factory(DynamicAttribute::class)->create();
         }
 
-        Artisan::call(
-            'dynamic-attributes:export',
-            [
-                '--yes' => true,
-                'name' => 'custom-attributes'
-            ]
-        );
+        Artisan::call('dynamic-attributes:export', [
+                '--yes' => true, 'name' => 'custom-attributes'
+            ]);
 
         $this->disk->assertExists(DynamicAttributeImportExportHelper::getFilePath("custom-attributes"));
         $fileData = $this->disk->get(DynamicAttributeImportExportHelper::getFilePath("custom-attributes"));
 
         $array = json_decode($fileData, JSON_OBJECT_AS_ARRAY);
         $this->assertIsArray($array);
-        $this->assertEquals(count($array), 50);
+        $this->assertEquals(count($array), 3);
 
         foreach ($array as $id => $type) {
             $dynamicAttribute = DynamicAttribute::firstWhere('attribute_id', $id);
@@ -150,40 +138,29 @@ class ImportExportDynamicAttributesTest extends TestCase
 
         $name = 'custom-attributes';
 
-
         $dummyData = "Dummy file data";
         $this->disk->put(DynamicAttributeImportExportHelper::getFilePath($name), $dummyData);
 
-        Artisan::call(
-            'dynamic-attributes:export',
-            [
-                '--yes' => true,
-                '--overwrite' => false,
-                'name' => $name
-            ]
-        );
+        Artisan::call('dynamic-attributes:export', [
+                '--yes' => true, '--overwrite' => false, 'name' => $name
+            ]);
 
         /* Check file is not overwritten */
         $this->disk->assertExists(DynamicAttributeImportExportHelper::getFilePath($name));
         $this->assertEquals($dummyData, $this->disk->get(DynamicAttributeImportExportHelper::getFilePath($name)));
 
 
-        for ($i = 0; $i < 50; $i++) {
+        for ($i = 0; $i < 3; $i++) {
             factory(DynamicAttribute::class)->create();
         }
-        Artisan::call(
-            'dynamic-attributes:export',
-            [
-                '--yes' => true,
-                '--overwrite' => true,
-                'name' => $name
-            ]
-        );
+        Artisan::call('dynamic-attributes:export', [
+                '--yes' => true, '--overwrite' => true, 'name' => $name
+            ]);
 
         $fileData = $this->disk->get(DynamicAttributeImportExportHelper::getFilePath($name));
         $array = json_decode($fileData, JSON_OBJECT_AS_ARRAY);
         $this->assertIsArray($array);
-        $this->assertEquals(count($array), 50);
+        $this->assertEquals(count($array), 3);
 
         foreach ($array as $id => $type) {
             $dynamicAttribute = DynamicAttribute::firstWhere('attribute_id', $id);

--- a/tests/Feature/ImportExportDynamicAttributesTest.php
+++ b/tests/Feature/ImportExportDynamicAttributesTest.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\ImportExportHelpers\DynamicAttributeImportExportHelper;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Storage;
+use OpenDialogAi\Core\DynamicAttribute;
+use Tests\TestCase;
+
+/**
+ * Class ImportExportIntentsTest
+ * @package Tests\Feature
+ * @group SpecificationTests
+ */
+class ImportExportDynamicAttributesTest extends TestCase
+{
+
+    /**
+     * @var \Illuminate\Contracts\Filesystem\Filesystem
+     */
+    protected $disk;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        DynamicAttribute::truncate();
+        $this->disk = Storage::fake('specification');
+    }
+
+    public function testImportInvalidJSON()
+    {
+        $notJSON = '
+            { "test_dynamic_attribute_a" => "attribute.core.string",
+            "test_dynamic_attribute_b" => "attribute.core.int",
+        ';
+
+        $this->disk->put(DynamicAttributeImportExportHelper::getFilePath('good-custom-attributes'), $notJSON);
+
+        Artisan::call(
+            'dynamic-attributes:import',
+            [
+                '--yes' => true,
+                'name' => 'good-custom-attributes'
+            ]
+        );
+
+        $this->assertDatabaseMissing('dynamic_attributes', ['attribute_id' => "test_dynamic_attribute_a", 'attribute_type' => "attribute.core.string"]);
+        $this->assertDatabaseMissing('dynamic_attributes', ['attribute_id' => "test_dynamic_attribute_b", 'attribute_type' => "attribute.core.int"]);
+
+    }
+
+    public function testImportInvalidAttributeIds()
+    {
+
+        foreach (DynamicAttributesTest::invalidIds as $id) {
+            $data = [$id => 'attribute.core.string'];
+            $this->disk->put(DynamicAttributeImportExportHelper::getFilePath('invalid-ids-attributes'), json_encode($data));
+
+            Artisan::call(
+                'dynamic-attributes:import',
+                [
+                    '--yes' => true,
+                    'name' => 'invalid-ids-attributes'
+                ]
+            );
+            $this->assertDatabaseMissing('dynamic_attributes', ['attribute_id' => $id, 'attribute_type' => "attribute.core.string"]);
+
+        }
+
+    }
+
+    public function testImportInvalidAttributeTypes()
+    {
+
+        foreach (DynamicAttributesTest::invalidTypes as $type) {
+            $data = ["dynamic_attribute_test" => $type];
+            $this->disk->put(DynamicAttributeImportExportHelper::getFilePath('invalid-types-attributes'), json_encode($data));
+
+            Artisan::call(
+                'dynamic-attributes:import',
+                [
+                    '--yes' => true,
+                    'name' => 'invalid-types-attributes'
+                ]
+            );
+
+            $this->assertDatabaseMissing('dynamic_attributes', ['attribute_id' => "dynamic_attribute_test", 'attribute_type' => $type]);
+        }
+
+    }
+
+    public function testSuccessfulImport()
+    {
+
+        $goodData = [
+            'test_dynamic_attribute_a' => 'attribute.core.string',
+            'test_dynamic_attribute_b' => 'attribute.core.int',
+            'test_dynamic_attribute_c' => 'attribute.core.string'
+        ];
+
+        $this->disk->put(DynamicAttributeImportExportHelper::getFilePath('good-custom-attributes'), json_encode($goodData));
+
+        Artisan::call(
+            'dynamic-attributes:import',
+            [
+                '--yes' => true,
+                'name' => 'good-custom-attributes'
+            ]
+        );
+
+        foreach ($goodData as $attribute_id => $attribute_type) {
+            $this->assertDatabaseHas('dynamic_attributes', ['attribute_id' => $attribute_id, 'attribute_type' => $attribute_type]);
+        }
+
+    }
+
+    public function testExportSuccess()
+    {
+        for ($i = 0; $i < 50; $i++) {
+            factory(DynamicAttribute::class)->create();
+        }
+
+        Artisan::call(
+            'dynamic-attributes:export',
+            [
+                '--yes' => true,
+                'name' => 'custom-attributes'
+            ]
+        );
+
+        $this->disk->assertExists(DynamicAttributeImportExportHelper::getFilePath("custom-attributes"));
+        $fileData = $this->disk->get(DynamicAttributeImportExportHelper::getFilePath("custom-attributes"));
+
+        $array = json_decode($fileData, JSON_OBJECT_AS_ARRAY);
+        $this->assertIsArray($array);
+        $this->assertEquals(count($array), 50);
+
+        foreach ($array as $id => $type) {
+            $dynamicAttribute = DynamicAttribute::firstWhere('attribute_id', $id);
+            $this->assertNotNull($dynamicAttribute);
+            $this->assertEquals($dynamicAttribute->attribute_id, $id);
+            $this->assertEquals($dynamicAttribute->attribute_type, $type);
+        }
+    }
+
+    public function testExportOverwrite()
+    {
+
+        $name = 'custom-attributes';
+
+
+        $dummyData = "Dummy file data";
+        $this->disk->put(DynamicAttributeImportExportHelper::getFilePath($name), $dummyData);
+
+        Artisan::call(
+            'dynamic-attributes:export',
+            [
+                '--yes' => true,
+                '--overwrite' => false,
+                'name' => $name
+            ]
+        );
+
+        /* Check file is not overwritten */
+        $this->disk->assertExists(DynamicAttributeImportExportHelper::getFilePath($name));
+        $this->assertEquals($dummyData, $this->disk->get(DynamicAttributeImportExportHelper::getFilePath($name)));
+
+
+        for ($i = 0; $i < 50; $i++) {
+            factory(DynamicAttribute::class)->create();
+        }
+        Artisan::call(
+            'dynamic-attributes:export',
+            [
+                '--yes' => true,
+                '--overwrite' => true,
+                'name' => $name
+            ]
+        );
+
+        $fileData = $this->disk->get(DynamicAttributeImportExportHelper::getFilePath($name));
+        $array = json_decode($fileData, JSON_OBJECT_AS_ARRAY);
+        $this->assertIsArray($array);
+        $this->assertEquals(count($array), 50);
+
+        foreach ($array as $id => $type) {
+            $dynamicAttribute = DynamicAttribute::firstWhere('attribute_id', $id);
+            $this->assertNotNull($dynamicAttribute);
+            $this->assertEquals($dynamicAttribute->attribute_id, $id);
+            $this->assertEquals($dynamicAttribute->attribute_type, $type);
+        }
+    }
+}


### PR DESCRIPTION
Adds the ability to create 'dynamic attributes' that are stored in the database rather than config files.

Depends on this PR for core: https://github.com/opendialogai/core/pull/428

Adds new `/admin/api/dynamic-attribute` api resource with support for CRUD of DynamicAttribute model. 
Adds new `/admin/api/dynamic-attributes/{upload,download}` (note the s) routes for uploading/downloading all dynamic-attributes as JSON. 

Adds new `dynamic-attributes:import` and `dynamic-attributes:export` artisan commands for exporting the dynamic-attributes to a .json file.

See app/Http/Controllers/API/DynamicAttributesController.php