### PR TITLE
Updates the scenarios routes and controllers to be more Laravel:

### DIFF
--- a/app/Http/Facades/Serializer.php
+++ b/app/Http/Facades/Serializer.php
@@ -6,14 +6,13 @@ namespace App\Http\Facades;
 use App\Http\Serializers\ConversationSerializer;
 use Illuminate\Support\Facades\Facade;
 
+/**
+ * @method static serialize($data, string $format, array $context = []): string
+ * @method static deserialize($data, string $type, string $format, array $context = [])
+ * @method static getSerializer(): Serializer
+ **/
 class Serializer extends Facade
 {
-
-    /**
-     * @method static function serialize($data, string $format, array $context = []): string
-     * @method static function deserialize($data, string $type, string $format, array $context = [])
-     * @method static function getSerializer(): Serializer
-     **/
     protected static function getFacadeAccessor()
     {
         return ConversationSerializer::class;

--- a/app/Http/Requests/ScenarioRequest.php
+++ b/app/Http/Requests/ScenarioRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Rules\Status;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ScenarioRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'uid' => 'string',
+            'odID' => 'string',
+            'name' => 'string',
+            'description' => 'string',
+            'defaultInterpreter' => 'string',
+            'behaviours' => 'array',
+            'conditions' => 'array',
+            'status' => ['string', new Status],
+            'conversations' => 'array'
+        ];
+    }
+}

--- a/app/Http/Resources/ScenarioResource.php
+++ b/app/Http/Resources/ScenarioResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Http\Facades\Serializer;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ScenarioResource extends JsonResource
+{
+    public static $wrap = null;
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return json_decode(Serializer::serialize($this->resource, 'json'));
+    }
+}

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -2,8 +2,10 @@
 
 namespace App\Providers;
 
-use Illuminate\Support\Facades\Route;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
+use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
 
 class RouteServiceProvider extends ServiceProvider
 {
@@ -23,7 +25,13 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        // Sets up custom route binding for user in routes files
+        Route::bind('scenario', function ($value) {
+            if ($scenario = ConversationDataClient::getScenarioByUid($value, false)) {
+                return $scenario;
+            }
+            throw new ModelNotFoundException(sprintf('Scenario with ID %s not found', $value));
+        });
 
         parent::boot();
     }

--- a/app/Rules/Status.php
+++ b/app/Rules/Status.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class Status implements Rule
+{
+    public static array $validStatuses = ['DRAFT', 'PUBLISHED', 'LIVE'];
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        return in_array($value, self::$validStatuses);
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return sprintf(':value is not a valid :attribute. Must be one of %s', implode(',', self::$validStatuses));
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -2548,12 +2548,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "909c27ab1b295a9cfb1577a8a76654dc3980343a"
+                "reference": "5cf69b423f79db4aef2fc18d72d996e629d788da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/909c27ab1b295a9cfb1577a8a76654dc3980343a",
-                "reference": "909c27ab1b295a9cfb1577a8a76654dc3980343a",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/5cf69b423f79db4aef2fc18d72d996e629d788da",
+                "reference": "5cf69b423f79db4aef2fc18d72d996e629d788da",
                 "shasum": ""
             },
             "require": {
@@ -2633,7 +2633,7 @@
                 "issues": "https://github.com/opendialogai/core/issues",
                 "source": "https://github.com/opendialogai/core/tree/feature/Serializers"
             },
-            "time": "2021-03-09T20:14:42+00:00"
+            "time": "2021-03-10T17:27:11+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -31,6 +31,8 @@
         <env name="SESSION_DRIVER" value="array"/>
         <env name="DB_CONNECTION" value="testbench"/>
         <env name="DB_DATABASE" value=":memory:"/>
+        <env name="DGRAPH_BASE_URL" value="dgraph-server-test"/>
+        <env name="DGRAPH_INSTANCE_TYPE" value="DGRAPH"/>
         <env name="DGRAPH_URL" value="dgraph-server-test"/>
         <env name="DGRAPH_PORT" value="8082"/>
         <env name="DGRAPH_AUTH_TOKEN" value="dgraphtestservertoken"/>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
 
 /*
 |--------------------------------------------------------------------------
@@ -110,12 +111,7 @@ Route::namespace('API')
         Route::post('specification-import', 'SpecificationController@import');
         Route::get('specification-export', 'SpecificationController@export');
 
-
         Route::prefix('conversation-builder')->group(function () {
-            Route::get('scenarios', 'ScenariosController@index');
-            Route::get('scenarios/{id}', 'ScenariosController@show');
-            Route::post('scenarios', 'ScenariosController@store');
-            Route::put('scenarios/{id}', 'ScenariosController@update');
-            Route::delete('scenarios/{id}', 'ScenariosController@destroy');
+            Route::apiResource('scenarios', 'ScenariosController');
         });
     });


### PR DESCRIPTION
+ Uses a custom model binder for `scenario` in route names so that we don't need to handle fetching in controller methods
+ Uses a new Scenario Resource to handle serialisation
+ Updates route file to use `apiResource` rather than specify each route name
+ Uses a ScenarioRequest class to perform initial validation
+ Adds a custom validator for status as an example