### PR TITLE
updates naming of `behaviours` to `behaviors` to match other mentions

### DIFF
--- a/app/Http/Requests/IntentRequest.php
+++ b/app/Http/Requests/IntentRequest.php
@@ -33,7 +33,7 @@ class IntentRequest extends FormRequest
             'confidence' => 'string',
             'sample_utterance' => 'string',
             'speaker' => 'string',
-            'behaviours' => 'array',
+            'behaviors' => 'array',
             'conditions' => 'array',
             'transitions' => 'array',
             'expected_attributes' => 'array',

--- a/app/Http/Requests/ScenarioRequest.php
+++ b/app/Http/Requests/ScenarioRequest.php
@@ -30,7 +30,7 @@ class ScenarioRequest extends FormRequest
             'name' => 'string',
             'description' => 'string',
             'defaultInterpreter' => 'string',
-            'behaviours' => 'array',
+            'behaviors' => 'array',
             'conditions' => 'array',
             'status' => ['string', new Status],
             'conversations' => 'array'

--- a/app/Http/Requests/SceneRequest.php
+++ b/app/Http/Requests/SceneRequest.php
@@ -30,7 +30,7 @@ class SceneRequest extends FormRequest
             'name' => 'string',
             'description' => 'string',
             'interpreter' => 'nullable|string',
-            'behaviours' => 'array',
+            'behaviors' => 'array',
             'conditions' => 'array',
             'turns' => 'array'
         ];

--- a/app/Http/Requests/TurnRequest.php
+++ b/app/Http/Requests/TurnRequest.php
@@ -30,7 +30,7 @@ class TurnRequest extends FormRequest
             'name' => 'string',
             'description' => 'string',
             'interpreter' => 'nullable|string',
-            'behaviours' => 'array',
+            'behaviors' => 'array',
             'conditions' => 'array',
             'valid_origins' => 'array',
             'intents' => 'array'


### PR DESCRIPTION
We have gone with the canonical spelling of `behaviors` rather than `behaviours`. Changes have been made to the front end to match in this PR: https://github.com/opendialogai/opendialog-design-system/pull/61


This PR gets the final mentions of `behaviors` in the Opendialog app code