### PR TITLE
Defining default conversation setup

### DIFF
--- a/tests/Feature/ScenariosTest.php
+++ b/tests/Feature/ScenariosTest.php
@@ -12,6 +12,8 @@ use OpenDialogAi\Core\Conversation\Exceptions\ConversationObjectNotFoundExceptio
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
 use OpenDialogAi\Core\Conversation\Scenario;
 use OpenDialogAi\Core\Conversation\ScenarioCollection;
+use OpenDialogAi\ResponseEngine\MessageTemplate;
+use OpenDialogAi\ResponseEngine\OutgoingIntent;
 use Tests\TestCase;
 
 class ScenariosTest extends TestCase
@@ -190,15 +192,10 @@ class ScenariosTest extends TestCase
             "conversations": [{"id": "0x0001"}]
         }', true));
 
-        ConversationDataClient::shouldReceive('addScenario')
+        ConversationDataClient::shouldReceive('addFullScenarioGraph')
             ->once()
             ->with($fakeScenario)
             ->andReturn($fakeScenarioCreated);
-
-        ConversationDataClient::shouldReceive('addConversation')
-            ->once()
-            ->withAnyArgs()
-            ->andReturn($fakeConversationCreated);
 
         $this->actingAs($this->user, 'api')
             ->json('POST', '/admin/api/conversation-builder/scenarios/', [
@@ -214,6 +211,9 @@ class ScenariosTest extends TestCase
                 'description' =>  'An example scenario',
                 'conversations' => [['id' => $fakeConversationCreated->getUid()]]
             ]);
+
+        $this->assertCount(2, OutgoingIntent::all());
+        $this->assertCount(2, MessageTemplate::all());
     }
 
     public function testUpdateScenarioNotFound()


### PR DESCRIPTION
This PR expands upon the previous default setup when creating a scenario. Previously only a "welcome" conversation was set up with no child objects and no behaviours. This PR ensures the following is set up:

**Welcome conversation:**

- Conversation with starting behaviour
- Scene with starting behaviour
- Turn with starting behaviour
- Request user intent with ID “intent.core.welcome” and interpreter “interpreter.core.callbackInterpreter”
- Response app intent with completing behaviour
- Message template for the created app intent

**No-match conversation:**

- Conversation with starting behaviour
- Scene with starting behaviour
- Turn with starting behaviour
- Request user intent with ID “intent.core.NoMatch” and interpreter “interpreter.core.callbackInterpreter”
- Response app intent with completing behaviour
- Message template for the created app intent