### PR TITLE
Feature/opndlg 553 intents mass update

### DIFF
--- a/app/Http/Controllers/API/UIStateController.php
+++ b/app/Http/Controllers/API/UIStateController.php
@@ -112,8 +112,13 @@ class UIStateController extends Controller
     public function massUpdateIntents(MassIntentRequest $request, Turn $turn, $type): FocusedTurnResource
     {
         $participant = $request->participant;
-        $responseParticipant = $type == 'response' ? $participant : ($participant === 'APP' ? 'USER' : 'APP');
-        $requestParticipant = $responseParticipant === 'APP' ? 'USER' : 'APP';
+        if ($type === 'response') {
+            $responseParticipant = $participant;
+            $requestParticipant = $this->getOppositeParticipant($responseParticipant);
+        } else {
+            $requestParticipant = $participant;
+            $responseParticipant = $this->getOppositeParticipant($requestParticipant);
+        }
 
         $turn->getRequestIntents()->each(function (Intent $intent) use ($requestParticipant) {
             $intent->setSpeaker($requestParticipant);
@@ -126,5 +131,16 @@ class UIStateController extends Controller
         });
 
         return $this->showFocusedTurn($turn);
+    }
+
+    /**
+     * Returns the opposite of the given participant - either APP or USER
+     *
+     * @param $participant
+     * @return string
+     */
+    private function getOppositeParticipant($participant): string
+    {
+        return $participant === 'APP' ? 'USER' : 'APP';
     }
 }

--- a/app/Http/Controllers/API/UIStateController.php
+++ b/app/Http/Controllers/API/UIStateController.php
@@ -4,13 +4,13 @@
 namespace App\Http\Controllers\API;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\MassIntentRequest;
 use App\Http\Resources\ConversationTreeResource;
 use App\Http\Resources\FocusedConversationResource;
 use App\Http\Resources\FocusedIntentResource;
 use App\Http\Resources\FocusedScenarioResource;
 use App\Http\Resources\FocusedSceneResource;
 use App\Http\Resources\FocusedTurnResource;
-use App\Http\Resources\ScenarioResource;
 use OpenDialogAi\Core\Conversation\Conversation;
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
 use OpenDialogAi\Core\Conversation\Intent;
@@ -101,5 +101,30 @@ class UIStateController extends Controller
     {
         $conversationTree = ConversationDataClient::getConversationTreeByScenarioUid($scenario->getUid());
         return new ConversationTreeResource($conversationTree);
+    }
+
+    /**
+     * @param MassIntentRequest $request
+     * @param Turn $turn
+     * @param $type
+     * @return FocusedTurnResource
+     */
+    public function massUpdateIntents(MassIntentRequest $request, Turn $turn, $type): FocusedTurnResource
+    {
+        $participant = $request->participant;
+        $responseParticipant = $type == 'response' ? $participant : ($participant === 'APP' ? 'USER' : 'APP');
+        $requestParticipant = $responseParticipant === 'APP' ? 'USER' : 'APP';
+
+        $turn->getRequestIntents()->each(function (Intent $intent) use ($requestParticipant) {
+            $intent->setSpeaker($requestParticipant);
+            ConversationDataClient::updateIntent($intent);
+        });
+
+        $turn->getResponseIntents()->each(function (Intent $intent) use ($responseParticipant) {
+            $intent->setSpeaker($responseParticipant);
+            ConversationDataClient::updateIntent($intent);
+        });
+
+        return $this->showFocusedTurn($turn);
     }
 }

--- a/app/Http/Requests/MassIntentRequest.php
+++ b/app/Http/Requests/MassIntentRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class MassIntentRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'participant' => ['required', Rule::in(['USER', 'APP'])],
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -153,6 +153,9 @@ Route::namespace('API')
             Route::get('ui-state/focused/intent/{intent}', 'UIStateController@showFocusedIntent');
 
             Route::get('ui-state/scenarios/{scenario}/tree', 'UIStateController@showConversationTree');
+
+            Route::patch('ui-state/turns/{turn}/intents/{type}', 'UIStateController@massUpdateIntents')
+                ->where('type', '(request)|(response)');
         });
 
         Route::post('conversation-simulation', 'ConversationSimulationController@simulate');


### PR DESCRIPTION
This PR adds a new API in the `ui-state` API namespace that updates the speaker of a turn's intents altogether.

The route includes the intent `{type}` which should be `request` or `response` - anything else should get a 404.

The body of the request just needs to include a value for `participant` which should be `APP` or `USER` - anything else will get a validation error.

For a successful call, the speaker should be updated for all intents against the turn, and send the same response as sent for the focused turn API