### PR TITLE
Transitions & conditions import/export bug

### DIFF
--- a/app/Console/Commands/Specification/ExportScenarios.php
+++ b/app/Console/Commands/Specification/ExportScenarios.php
@@ -4,8 +4,10 @@
 namespace App\Console\Commands\Specification;
 
 use App\Console\Facades\ImportExportSerializer;
+use App\ImportExportHelpers\PathSubstitutionHelper;
 use App\ImportExportHelpers\ScenarioImportExportHelper;
 use Illuminate\Console\Command;
+use OpenDialogAi\Core\Conversation\DataClients\Serializers\Normalizers\ImportExport\ScenarioNormalizer;
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
 use OpenDialogAi\Core\Conversation\Scenario;
 
@@ -29,7 +31,9 @@ class ExportScenarios extends Command
     public function exportScenario(Scenario $fullScenarioGraph)
     {
         $filePath = ScenarioImportExportHelper::getScenarioFilePath($fullScenarioGraph->getOdId());
-        $serialized = ImportExportSerializer::serialize($fullScenarioGraph, 'json');
+        $serialized = ImportExportSerializer::serialize($fullScenarioGraph, 'json', [
+            ScenarioNormalizer::UID_MAP => PathSubstitutionHelper::createConversationObjectUidToPathMap($fullScenarioGraph)
+        ]);
 
         if (ScenarioImportExportHelper::scenarioFileExists($filePath)) {
             $this->info(sprintf("Scenario file at %s already exists. Deleting...", $filePath));

--- a/app/Console/Facades/ImportExportSerializer.php
+++ b/app/Console/Facades/ImportExportSerializer.php
@@ -3,7 +3,9 @@
 
 namespace App\Console\Facades;
 
+use Ds\Map;
 use Illuminate\Support\Facades\Facade;
+use OpenDialogAi\Core\Conversation\Scenario;
 
 
 /**

--- a/app/Console/Facades/ImportExportSerializer.php
+++ b/app/Console/Facades/ImportExportSerializer.php
@@ -3,10 +3,7 @@
 
 namespace App\Console\Facades;
 
-use Ds\Map;
 use Illuminate\Support\Facades\Facade;
-use OpenDialogAi\Core\Conversation\Scenario;
-
 
 /**
  * @method static serialize($data, string $format, array $context = []): string

--- a/app/Console/Serializers/ImportExportSerializer.php
+++ b/app/Console/Serializers/ImportExportSerializer.php
@@ -7,10 +7,20 @@ use OpenDialogAi\Core\Conversation\DataClients\Serializers\BehaviorsCollectionNo
 use OpenDialogAi\Core\Conversation\DataClients\Serializers\ConditionCollectionNormalizer;
 use OpenDialogAi\Core\Conversation\DataClients\Serializers\ConversationCollectionNormalizer;
 use OpenDialogAi\Core\Conversation\DataClients\Serializers\IntentCollectionNormalizer;
+use OpenDialogAi\Core\Conversation\DataClients\Serializers\Normalizers\ImportExport\BehaviorNormalizer;
+use OpenDialogAi\Core\Conversation\DataClients\Serializers\Normalizers\ImportExport\ConditionNormalizer;
+use OpenDialogAi\Core\Conversation\DataClients\Serializers\Normalizers\ImportExport\ConversationNormalizer;
+use OpenDialogAi\Core\Conversation\DataClients\Serializers\Normalizers\ImportExport\IntentNormalizer;
+use OpenDialogAi\Core\Conversation\DataClients\Serializers\Normalizers\ImportExport\ScenarioNormalizer;
+use OpenDialogAi\Core\Conversation\DataClients\Serializers\Normalizers\ImportExport\SceneNormalizer;
+use OpenDialogAi\Core\Conversation\DataClients\Serializers\Normalizers\ImportExport\TransitionNormalizer;
+use OpenDialogAi\Core\Conversation\DataClients\Serializers\Normalizers\ImportExport\TurnNormalizer;
+use OpenDialogAi\Core\Conversation\DataClients\Serializers\Normalizers\ImportExport\VirtualIntentNormalizer;
 use OpenDialogAi\Core\Conversation\DataClients\Serializers\ScenarioCollectionNormalizer;
 use OpenDialogAi\Core\Conversation\DataClients\Serializers\SceneCollectionNormalizer;
 use OpenDialogAi\Core\Conversation\DataClients\Serializers\TurnCollectionNormalizer;
 use OpenDialogAi\Core\Conversation\DataClients\Serializers\VirtualIntentCollectionNormalizer;
+use Symfony\Component\Serializer\Encoder\JsonEncode;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\Serializer;
@@ -23,37 +33,37 @@ class ImportExportSerializer
     {
         $normalizers = [
             new ScenarioCollectionNormalizer(),
-            new \OpenDialogAi\Core\Conversation\DataClients\Serializers\Normalizers\ImportExport\ScenarioNormalizer(),
+            new ScenarioNormalizer(),
             new ConversationCollectionNormalizer(),
-            new \OpenDialogAi\Core\Conversation\DataClients\Serializers\Normalizers\ImportExport\ConversationNormalizer(),
+            new ConversationNormalizer(),
             new SceneCollectionNormalizer(),
-            new \OpenDialogAi\Core\Conversation\DataClients\Serializers\Normalizers\ImportExport\SceneNormalizer(),
+            new SceneNormalizer(),
             new TurnCollectionNormalizer(),
-            new \OpenDialogAi\Core\Conversation\DataClients\Serializers\Normalizers\ImportExport\TurnNormalizer(),
+            new TurnNormalizer(),
             new IntentCollectionNormalizer(),
-            new \OpenDialogAi\Core\Conversation\DataClients\Serializers\Normalizers\ImportExport\IntentNormalizer(),
+            new IntentNormalizer(),
             new ConditionCollectionNormalizer(),
-            new \OpenDialogAi\Core\Conversation\DataClients\Serializers\Normalizers\ImportExport\ConditionNormalizer(),
+            new ConditionNormalizer(),
             new BehaviorsCollectionNormalizer(),
-            new \OpenDialogAi\Core\Conversation\DataClients\Serializers\Normalizers\ImportExport\BehaviorNormalizer(),
+            new BehaviorNormalizer(),
             new VirtualIntentCollectionNormalizer(),
-            new \OpenDialogAi\Core\Conversation\DataClients\Serializers\Normalizers\ImportExport\VirtualIntentNormalizer(),
-            new \OpenDialogAi\Core\Conversation\DataClients\Serializers\Normalizers\ImportExport\TransitionNormalizer()
+            new VirtualIntentNormalizer(),
+            new TransitionNormalizer()
         ];
-        $encoders = [new JsonEncoder()];
+        $encoders = [new JsonEncoder(new JsonEncode([JsonEncode::OPTIONS => JSON_UNESCAPED_SLASHES]))];
         $this->serializer = new Serializer($normalizers, $encoders);
     }
 
     /**
      * @param          $data
-     * @param  string  $format
-     *
+     * @param string $format
+     * @param array $context
      * @return string serialized object in the form of a string
      */
-    public function serialize($data, string $format): string
+    public function serialize($data, string $format, array $context = []): string
     {
         return $this->getSerializer()
-            ->serialize($data, $format);
+            ->serialize($data, $format, $context);
     }
 
     /**

--- a/app/Http/Requests/ConversationObjectRequestTrait.php
+++ b/app/Http/Requests/ConversationObjectRequestTrait.php
@@ -12,7 +12,7 @@ trait ConversationObjectRequestTrait
     public function odIdRule(ConversationObject $parent = null): array
     {
         return [
-            'od_id' => ['string', 'required', 'not_regex:/[\$\:\/]/', new OdId($parent)],
+            'od_id' => ['bail', 'string', 'filled', 'not_regex:/[\$\:\/]/', new OdId($parent)],
         ];
     }
 }

--- a/app/Http/Requests/ConversationObjectRequestTrait.php
+++ b/app/Http/Requests/ConversationObjectRequestTrait.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace App\Http\Requests;
+
+
+use App\Rules\OdId;
+use OpenDialogAi\Core\Conversation\ConversationObject;
+
+trait ConversationObjectRequestTrait
+{
+    public function odIdRule(ConversationObject $parent = null): array
+    {
+        return [
+            'od_id' => ['string', 'required', 'not_regex:/[\$\:\/]/', new OdId($parent)],
+        ];
+    }
+}

--- a/app/Http/Requests/ConversationRequest.php
+++ b/app/Http/Requests/ConversationRequest.php
@@ -5,9 +5,12 @@ namespace App\Http\Requests;
 
 use App\Rules\Status;
 use Illuminate\Foundation\Http\FormRequest;
+use OpenDialogAi\Core\Conversation\ConversationObject;
 
 class ConversationRequest extends FormRequest
 {
+    use ConversationObjectRequestTrait;
+
     /**
      * Determine if the user is authorized to make this request.
      *
@@ -25,9 +28,11 @@ class ConversationRequest extends FormRequest
      */
     public function rules()
     {
-        return [
+        /** @var ConversationObject $parent */
+        $parent = $this->route('scenario');
+
+        return $this->odIdRule($parent) + [
             'uid' => 'string',
-            'odID' => 'string',
             'name' => 'string'
         ];
     }

--- a/app/Http/Requests/ConversationRequest.php
+++ b/app/Http/Requests/ConversationRequest.php
@@ -3,7 +3,6 @@
 
 namespace App\Http\Requests;
 
-use App\Rules\Status;
 use Illuminate\Foundation\Http\FormRequest;
 use OpenDialogAi\Core\Conversation\ConversationObject;
 

--- a/app/Http/Requests/ScenarioRequest.php
+++ b/app/Http/Requests/ScenarioRequest.php
@@ -7,6 +7,8 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class ScenarioRequest extends FormRequest
 {
+    use ConversationObjectRequestTrait;
+
     /**
      * Determine if the user is authorized to make this request.
      *
@@ -24,9 +26,8 @@ class ScenarioRequest extends FormRequest
      */
     public function rules()
     {
-        return [
+        return $this->odIdRule() + [
             'uid' => 'string',
-            'odID' => 'string',
             'name' => 'string',
             'description' => 'string',
             'defaultInterpreter' => 'string',

--- a/app/Http/Requests/SceneRequest.php
+++ b/app/Http/Requests/SceneRequest.php
@@ -4,9 +4,12 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use OpenDialogAi\Core\Conversation\ConversationObject;
 
 class SceneRequest extends FormRequest
 {
+    use ConversationObjectRequestTrait;
+
     /**
      * Determine if the user is authorized to make this request.
      *
@@ -24,9 +27,11 @@ class SceneRequest extends FormRequest
      */
     public function rules()
     {
-        return [
+        /** @var ConversationObject $parent */
+        $parent = $this->route('conversation');
+
+        return $this->odIdRule($parent) + [
             'id' => 'string',
-            'od_id' => 'string',
             'name' => 'string',
             'description' => 'string',
             'interpreter' => 'nullable|string',

--- a/app/Http/Requests/TurnRequest.php
+++ b/app/Http/Requests/TurnRequest.php
@@ -4,9 +4,12 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use OpenDialogAi\Core\Conversation\ConversationObject;
 
 class TurnRequest extends FormRequest
 {
+    use ConversationObjectRequestTrait;
+
     /**
      * Determine if the user is authorized to make this request.
      *
@@ -24,9 +27,11 @@ class TurnRequest extends FormRequest
      */
     public function rules()
     {
-        return [
+        /** @var ConversationObject $parent */
+        $parent = $this->route('scene');
+
+        return $this->odIdRule($parent) + [
             'id' => 'string',
-            'od_id' => 'string',
             'name' => 'string',
             'description' => 'string',
             'interpreter' => 'nullable|string',

--- a/app/ImportExportHelpers/PathSubstitutionHelper.php
+++ b/app/ImportExportHelpers/PathSubstitutionHelper.php
@@ -1,0 +1,139 @@
+<?php
+
+
+namespace App\ImportExportHelpers;
+
+
+use Ds\Map;
+use OpenDialogAi\Core\Conversation\Conversation;
+use OpenDialogAi\Core\Conversation\ConversationObject;
+use OpenDialogAi\Core\Conversation\Intent;
+use OpenDialogAi\Core\Conversation\Scenario;
+use OpenDialogAi\Core\Conversation\Scene;
+use OpenDialogAi\Core\Conversation\Turn;
+
+class PathSubstitutionHelper
+{
+    public const PATH_PREFIX = '$path:';
+    public const PATH_COMPONENT_SEPARATOR = '/';
+
+    /**
+     * Maps uids to paths & vice-versa, eg.
+     * {
+     *   '0x123' => '$path:my_scenario,
+     *   '0x124' => '$path:my_scenario/my_conversation,
+     *   '0x125' => '$path:my_scenario/my_conversation/my_scene,
+     *   ...
+     *   '$path:my_scenario' => '0x123',
+     *   '$path:my_scenario/my_conversation' => '0x124',
+     *   '$path:my_scenario/my_conversation/my_scene' => '0x125',
+     *   ...
+     * }
+     *
+     * @param Scenario $scenario
+     * @return Map
+     */
+    public static function createConversationObjectUidToPathMap(Scenario $scenario): Map
+    {
+        $map = new Map();
+
+        $scenarioOdId = $scenario->getOdId();
+        $scenarioPath = PathSubstitutionHelper::createPath($scenarioOdId);
+
+        $map->put($scenario->getUid(), $scenarioPath);
+        $map->put($scenarioPath, $scenario->getUid());
+
+        foreach ($scenario->getConversations() as $conversation) {
+            /** @var Conversation $conversation */
+
+            $conversationOdId = $conversation->getOdId();
+            $conversationPath = PathSubstitutionHelper::createPath($scenarioOdId, $conversationOdId);
+
+            $map->put($conversation->getUid(), $conversationPath);
+            $map->put($conversationPath, $conversation->getUid());
+
+            foreach ($conversation->getScenes() as $scene) {
+                /** @var Scene $scene */
+
+                $sceneOdId = $scene->getOdId();
+                $scenePath = PathSubstitutionHelper::createPath($scenarioOdId, $conversationOdId, $sceneOdId);
+
+                $map->put($scene->getUid(), $scenePath);
+                $map->put($scenePath, $scene->getUid());
+
+                foreach ($scene->getTurns() as $turn) {
+                    /** @var Turn $turn */
+
+                    $turnOdId = $turn->getOdId();
+                    $turnPath = PathSubstitutionHelper::createPath($scenarioOdId, $conversationOdId, $sceneOdId, $turnOdId);
+
+                    $map->put($turn->getUid(), $turnPath);
+                    $map->put($turnPath, $turn->getUid());
+                }
+            }
+        }
+
+        return $map;
+    }
+
+    public static function stringContainsPaths(string $str): bool
+    {
+        return strpos($str, self::PATH_PREFIX) !== false;
+    }
+
+    /**
+     * @param string ...$odIds
+     * @return string
+     */
+    public static function createPath(string ...$odIds): string
+    {
+        $path = self::PATH_PREFIX . $odIds[0];
+
+        foreach (array_slice($odIds, 1) as $odId) {
+            $path .= self::PATH_COMPONENT_SEPARATOR . $odId;
+        }
+
+        return $path;
+    }
+
+    /**
+     * Whether or not the given object has path-value-substitutable objects that should be patched
+     *
+     * @param ConversationObject $object
+     * @return bool
+     */
+    public static function shouldPatch(ConversationObject $object): bool
+    {
+        if ($object->getConditions() && $object->getConditions()->isNotEmpty()) {
+            return true;
+        }
+
+        if ($object instanceof Intent && $object->getTransition() && !$object->getTransition()->isEmpty()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Dehydrates the given object so that only the given UID and path-value-substitutable objects remain
+     *
+     * @param string $uid
+     * @param ConversationObject $object
+     * @return ConversationObject
+     */
+    public static function createPatch(string $uid, ConversationObject $object): ConversationObject
+    {
+        $patchObject = clone $object;
+        $patchObject->dehydrate();
+
+        $patchObject->setUid($uid);
+        $patchObject->setConditions($object->getConditions());
+
+        if ($object instanceof Intent) {
+            $patchObject->setTransition($object->getTransition());
+        }
+
+        return $patchObject;
+    }
+}

--- a/app/ImportExportHelpers/ScenarioImportExportHelper.php
+++ b/app/ImportExportHelpers/ScenarioImportExportHelper.php
@@ -5,9 +5,14 @@ namespace App\ImportExportHelpers;
 
 
 use App\Console\Facades\ImportExportSerializer;
+use OpenDialogAi\Core\Conversation\Conversation;
+use OpenDialogAi\Core\Conversation\DataClients\Serializers\Normalizers\ImportExport\ScenarioNormalizer;
 use OpenDialogAi\Core\Conversation\Exceptions\DuplicateConversationObjectOdIdException;
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
+use OpenDialogAi\Core\Conversation\Intent;
 use OpenDialogAi\Core\Conversation\Scenario;
+use OpenDialogAi\Core\Conversation\Scene;
+use OpenDialogAi\Core\Conversation\Turn;
 
 class ScenarioImportExportHelper extends BaseImportExportHelper
 {
@@ -99,8 +104,18 @@ class ScenarioImportExportHelper extends BaseImportExportHelper
      */
     public static function importScenarioFromString(string $data): Scenario
     {
+        $hasPathsToSubstitute = PathSubstitutionHelper::stringContainsPaths($data);
+
+        $serializerContext = [];
+
+        if ($hasPathsToSubstitute) {
+            $serializerContext = [
+                ScenarioNormalizer::IGNORE_OBJECTS_WITH_POTENTIAL_PATH_VALUES => true,
+            ];
+        }
+
         /* @var $importingScenario Scenario */
-        $importingScenario = ImportExportSerializer::deserialize($data, Scenario::class, 'json');
+        $importingScenario = ImportExportSerializer::deserialize($data, Scenario::class, 'json', $serializerContext);
 
         $existingScenarios = ConversationDataClient::getAllScenarios(false);
 
@@ -110,7 +125,87 @@ class ScenarioImportExportHelper extends BaseImportExportHelper
                 sprintf("Cannot import scenario with odId %s. A scenario with that odId already exists!",
                 $importingScenario->getOdId()));
         }
-        return ConversationDataClient::addFullScenarioGraph($importingScenario);
+
+        $persistedScenario = ConversationDataClient::addFullScenarioGraph($importingScenario);
+
+        if (!$hasPathsToSubstitute) {
+            return $persistedScenario;
+        }
+
+        $map = PathSubstitutionHelper::createConversationObjectUidToPathMap($persistedScenario);
+
+        // Deserialize WITH objects with potential path values and substitute the paths for the UIDs
+        /** @var Scenario $scenarioWithPathsSubstituted */
+        $scenarioWithPathsSubstituted = ImportExportSerializer::deserialize($data, Scenario::class, 'json', [
+            ScenarioNormalizer::UID_MAP => $map
+        ]);
+
+        if (PathSubstitutionHelper::shouldPatch($scenarioWithPathsSubstituted)) {
+            $scenarioPatch = PathSubstitutionHelper::createPatch($persistedScenario->getUid(), $scenarioWithPathsSubstituted);
+            ConversationDataClient::updateScenario($scenarioPatch);
+        }
+
+        foreach ($scenarioWithPathsSubstituted->getConversations() as $cIdx => $conversation) {
+            /** @var Conversation $conversation */
+
+            /** @var Conversation $persistedConversation */
+            $persistedConversation = $persistedScenario->getConversations()[$cIdx];
+
+            if (PathSubstitutionHelper::shouldPatch($conversation)) {
+                $conversationPatch = PathSubstitutionHelper::createPatch($persistedConversation->getUid(), $conversation);
+                ConversationDataClient::updateConversation($conversationPatch);
+            }
+
+            foreach ($conversation->getScenes() as $sIdx => $scene) {
+                /** @var Scene $scene */
+
+                /** @var Scene $persistedScene */
+                $persistedScene = $persistedConversation->getScenes()[$sIdx];
+
+                if (PathSubstitutionHelper::shouldPatch($scene)) {
+                    $scenePatch = PathSubstitutionHelper::createPatch($persistedScene->getUid(), $scene);
+                    ConversationDataClient::updateScene($scenePatch);
+                }
+
+                foreach ($scene->getTurns() as $tIdx => $turn) {
+                    /** @var Turn $turn */
+
+                    /** @var Turn $persistedTurn */
+                    $persistedTurn = $persistedScene->getTurns()[$tIdx];
+
+                    if (PathSubstitutionHelper::shouldPatch($turn)) {
+                        $turnPatch = PathSubstitutionHelper::createPatch($persistedTurn->getUid(), $turn);
+                        ConversationDataClient::updateTurn($turnPatch);
+                    }
+
+                    foreach ($turn->getRequestIntents() as $iIdx => $intent) {
+                        /** @var Intent $intent */
+
+                        /** @var Intent $persistedIntent */
+                        $persistedIntent = $persistedTurn->getRequestIntents()[$iIdx];
+
+                        if (PathSubstitutionHelper::shouldPatch($intent)) {
+                            $intentPatch = PathSubstitutionHelper::createPatch($persistedIntent->getUid(), $intent);
+                            ConversationDataClient::updateIntent($intentPatch);
+                        }
+                    }
+
+                    foreach ($turn->getResponseIntents() as $iIdx => $intent) {
+                        /** @var Turn $intent */
+
+                        /** @var Intent $persistedIntent */
+                        $persistedIntent = $persistedTurn->getResponseIntents()[$iIdx];
+
+                        if (PathSubstitutionHelper::shouldPatch($intent)) {
+                            $intentPatch = PathSubstitutionHelper::createPatch($persistedIntent->getUid(), $intent);
+                            ConversationDataClient::updateIntent($intentPatch);
+                        }
+                    }
+                }
+            }
+        }
+
+        return ConversationDataClient::getFullScenarioGraph($persistedScenario->getUid());
     }
 }
 

--- a/app/Rules/OdId.php
+++ b/app/Rules/OdId.php
@@ -1,0 +1,81 @@
+<?php
+
+
+namespace App\Rules;
+
+
+use Illuminate\Contracts\Validation\Rule;
+use OpenDialogAi\Core\Conversation\Conversation;
+use OpenDialogAi\Core\Conversation\ConversationObject;
+use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
+use OpenDialogAi\Core\Conversation\ODObjectCollection;
+use OpenDialogAi\Core\Conversation\Scenario;
+use OpenDialogAi\Core\Conversation\Scene;
+
+class OdId implements Rule
+{
+    private ?ConversationObject $parent;
+
+    public function __construct(ConversationObject $parent = null)
+    {
+        $this->parent = $parent;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        return $this->isOdIdUniqueWithinParentScope($value, $this->parent);
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'OD ID is not a unique ID.';
+    }
+
+    /**
+     * Returns whether the given od_id is unique within the scope of the given parent. Eg. if the od_id is for a scene,
+     * that it is unique within the given (parent) conversation
+     *
+     * @param string $odId
+     * @param ConversationObject|null $parent If null the od_id represents a scenario
+     * @return bool
+     */
+    private function isOdIdUniqueWithinParentScope(string $odId, ConversationObject $parent = null): bool
+    {
+        $children = new ODObjectCollection();
+
+        if (is_null($parent)) {
+            $children = ConversationDataClient::getAllScenarios();
+        } else {
+            switch (get_class($parent)) {
+                case Scenario::class:
+                    /** @var Scenario $parent */
+                    $children = $parent->getConversations();
+                    break;
+
+                case Conversation::class:
+                    /** @var Conversation $parent */
+                    $children = $parent->getScenes();
+                    break;
+
+                case Scene::class:
+                    /** @var Scene $parent */
+                    $children = $parent->getTurns();
+                    break;
+            }
+        }
+
+        return $children->getObjectsWithId($odId)->isEmpty();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "laravel/tinker": "^2.0",
         "laravel/ui": "^3.0",
         "maennchen/zipstream-php": "^2.0",
-        "opendialogai/core": "1.x-dev",
+        "opendialogai/core": "dev-fix/OPNDLG-608--transition-import-export",
         "opendialogai/dgraph-docker": "20.11.0",
         "opendialogai/webchat": "1.x-dev",
         "phalcongelist/php-diff": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fe3c77b1387348bb288ff8b87d2e2757",
+    "content-hash": "7fd48347c59c56856712f859703ae3b6",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2547,16 +2547,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "1.x-dev",
+            "version": "dev-fix/OPNDLG-608--transition-import-export",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "d755ae4daa116f908b63f72eeb119e02ef967ab3"
+                "reference": "f3864f9b543732bf06d7a641ae35b28b828bf1e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/d755ae4daa116f908b63f72eeb119e02ef967ab3",
-                "reference": "d755ae4daa116f908b63f72eeb119e02ef967ab3",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/f3864f9b543732bf06d7a641ae35b28b828bf1e6",
+                "reference": "f3864f9b543732bf06d7a641ae35b28b828bf1e6",
                 "shasum": ""
             },
             "require": {
@@ -2583,7 +2583,6 @@
                 "phpunit/phpunit": "^9.0",
                 "squizlabs/php_codesniffer": "^3.4"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -2635,9 +2634,9 @@
             "description": "The OpenDialog Core package",
             "support": {
                 "issues": "https://github.com/opendialogai/core/issues",
-                "source": "https://github.com/opendialogai/core/tree/1.x"
+                "source": "https://github.com/opendialogai/core/tree/fix/OPNDLG-608--transition-import-export"
             },
-            "time": "2021-04-23T11:53:06+00:00"
+            "time": "2021-04-30T11:41:54+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/tests/Feature/ConversationsTest.php
+++ b/tests/Feature/ConversationsTest.php
@@ -224,13 +224,11 @@ class ConversationsTest extends TestCase
             ->json('PATCH', '/admin/api/conversation-builder/conversations/' . $fakeConversation->getUid(), [
                 'name' => $fakeConversationUpdated->getName(),
                 'id' => $fakeConversationUpdated->getUid(),
-                'od_id' => $fakeConversationUpdated->getODId(),
                 'description' =>  $fakeConversationUpdated->getDescription()
             ])
             //->assertStatus(200)
             ->assertJson([
                 "id" => "0x0001",
-                "od_id" => "new_example_conversation",
                 "name" => "New Example conversation updated",
                 "description" => "An new example conversation updated",
                 "interpreter" => "interpreter.core.nlp",

--- a/tests/Feature/ImportExportScenariosTest.php
+++ b/tests/Feature/ImportExportScenariosTest.php
@@ -455,8 +455,8 @@ class ImportExportScenariosTest extends TestCase
         $minimalScenarioFilePath = ScenarioImportExportHelper::getScenarioFilePath("minimal_scenario");
 
         // Run the Import (Storage mocked)
-        $storedExampleScenario = $this->addFakeUids($this->getMatchingExampleScenario());
-        $storedMinimalScenario = $this->addFakeUids($this->getMatchingMinimalScenario());
+        $storedExampleScenario = $this->getMatchingExampleScenario();
+        $storedMinimalScenario = $this->getMatchingMinimalScenario();
         ConversationDataClient::shouldReceive('getAllScenarios')->twice()->andReturn(new ScenarioCollection(), new
         ScenarioCollection([$storedExampleScenario]));
         ConversationDataClient::shouldReceive('addFullScenarioGraph')->twice()
@@ -492,8 +492,8 @@ class ImportExportScenariosTest extends TestCase
         $this->disk->put($filePath, $invalidScenarioJson);
 
         // Run import, mocking data for example_scenario.scenario.json and minimal_scenario.scenario.json
-        $storedExampleScenario = $this->addFakeUids($this->getMatchingExampleScenario());
-        $storedMinimalScenario = $this->addFakeUids($this->getMatchingMinimalScenario());
+        $storedExampleScenario = $this->getMatchingExampleScenario();
+        $storedMinimalScenario = $this->getMatchingMinimalScenario();
         ConversationDataClient::shouldReceive('getAllScenarios')->twice()->andReturn(new ScenarioCollection(), new
         ScenarioCollection([$storedExampleScenario]));
         ConversationDataClient::shouldReceive('addFullScenarioGraph')->twice()
@@ -519,7 +519,7 @@ class ImportExportScenariosTest extends TestCase
         $this->assertCount(1, $previousScenarios);
 
         // Run the Import (Storage mocked)
-        $storedMinimalScenario = $this->addFakeUids($this->getMatchingMinimalScenario());
+        $storedMinimalScenario = $this->getMatchingMinimalScenario();
         ConversationDataClient::shouldReceive('getAllScenarios')->twice()
             ->andReturn(new ScenarioCollection([$storedExistingExampleScenario]));
         ConversationDataClient::shouldReceive('addFullScenarioGraph')->once()->andReturn($storedMinimalScenario);
@@ -555,8 +555,8 @@ class ImportExportScenariosTest extends TestCase
         );
 
         // Round trip
-        $storedExampleScenario = $this->addFakeUids($this->getMatchingExampleScenario());
-        $storedMinimalScenario = $this->addFakeUids($this->getMatchingMinimalScenario());
+        $storedExampleScenario = $this->getMatchingExampleScenario();
+        $storedMinimalScenario = $this->getMatchingMinimalScenario();
 
         ConversationDataClient::shouldReceive('getAllScenarios')
             ->twice()

--- a/tests/Feature/ImportExportScenariosTest.php
+++ b/tests/Feature/ImportExportScenariosTest.php
@@ -10,6 +10,8 @@ use Illuminate\Support\Facades\Storage;
 use League\Flysystem\Adapter\AbstractAdapter;
 use OpenDialogAi\Core\Conversation\Behavior;
 use OpenDialogAi\Core\Conversation\BehaviorsCollection;
+use OpenDialogAi\Core\Conversation\Condition;
+use OpenDialogAi\Core\Conversation\ConditionCollection;
 use OpenDialogAi\Core\Conversation\Conversation;
 use OpenDialogAi\Core\Conversation\ConversationCollection;
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
@@ -334,7 +336,16 @@ class ImportExportScenariosTest extends TestCase
 
         $turn->addResponseIntent($responseIntent);
 
-        return $this->addFakeUids($scenario);
+        $this->addFakeUids($scenario);
+
+        $scenario->setConditions(new ConditionCollection([
+            new Condition('eq', ['attribute' => 'selected_scenario'], ['value' => $scenario->getUid()])
+        ]));
+
+        $requestIntent->setTransition(null);
+        $responseIntent->setTransition(new Transition($conversation->getUid(), $scene->getUid(), null));
+
+        return $scenario;
     }
 
     /**

--- a/tests/Feature/ImportExportScenariosTest.php
+++ b/tests/Feature/ImportExportScenariosTest.php
@@ -95,7 +95,7 @@ class ImportExportScenariosTest extends TestCase
      *
      * @return Scenario
      */
-    public function getFullTestScenario()
+    public function getFullTestScenario(): Scenario
     {
         /**
          * Scenario
@@ -358,7 +358,7 @@ class ImportExportScenariosTest extends TestCase
 
         // Mock storing the scenario in DGraph
         ConversationDataClient::shouldReceive('addFullScenarioGraph')->with($scenario)
-            ->andReturn($this->addFakeUids($this->getFullTestScenario()));
+            ->andReturn($this->addFakeUids($scenario));
         $storedScenario = ConversationDataClient::addFullScenarioGraph($scenario);
 
         $expectedFilePath = ScenarioImportExportHelper::getScenarioFilePath($storedScenario->getOdId());
@@ -549,31 +549,44 @@ class ImportExportScenariosTest extends TestCase
     {
         // Get data for existing scenario files.
         $previousScenarioFiles = ScenarioImportExportHelper::getScenarioFiles();
-        $previousScenarioFileData = array_combine($previousScenarioFiles,
-            array_map(fn($path) => ScenarioImportExportHelper::getScenarioFileData($path), $previousScenarioFiles));
+        $previousScenarioFileData = array_combine(
+            $previousScenarioFiles,
+            array_map(fn($path) => ScenarioImportExportHelper::getScenarioFileData($path), $previousScenarioFiles)
+        );
 
         // Round trip
         $storedExampleScenario = $this->addFakeUids($this->getMatchingExampleScenario());
         $storedMinimalScenario = $this->addFakeUids($this->getMatchingMinimalScenario());
-        ConversationDataClient::shouldReceive('getAllScenarios')->twice()->andReturn(new ScenarioCollection(), new
-        ScenarioCollection([$storedExampleScenario]));
-        ConversationDataClient::shouldReceive('addFullScenarioGraph')->twice()
+
+        ConversationDataClient::shouldReceive('getAllScenarios')
+            ->twice()
+            ->andReturn(
+                new ScenarioCollection(),
+                new ScenarioCollection([$storedExampleScenario])
+            );
+
+        ConversationDataClient::shouldReceive('addFullScenarioGraph')
+            ->twice()
             ->andReturn($storedExampleScenario, $storedMinimalScenario);
+
         $this->artisan('scenarios:import');
 
-        ConversationDataclient::shouldReceive('getAllScenarios')->once()->andReturn(new ScenarioCollection
-        ([
-            $storedExampleScenario,
-            $storedMinimalScenario
-        ]));
-        ConversationDataClient::shouldReceive('getFullScenarioGraph')->twice()
+        ConversationDataclient::shouldReceive('getAllScenarios')
+            ->once()
+            ->andReturn(new ScenarioCollection([$storedExampleScenario, $storedMinimalScenario]));
+
+        ConversationDataClient::shouldReceive('getFullScenarioGraph')
+            ->twice()
             ->andReturn($storedExampleScenario, $storedMinimalScenario);
+
         $this->artisan('scenarios:export');
 
         // Get data for current scenario files.
         $currentScenarioFiles = ScenarioImportExportHelper::getScenarioFiles();
-        $currentScenarioFilesData = array_combine($currentScenarioFiles,
-            array_map(fn($path) => ScenarioImportExportHelper::getScenarioFileData($path), $currentScenarioFiles));
+        $currentScenarioFilesData = array_combine(
+            $currentScenarioFiles,
+            array_map(fn($path) => ScenarioImportExportHelper::getScenarioFileData($path), $currentScenarioFiles)
+        );
 
         $this->assertEquals(count($previousScenarioFileData), count($currentScenarioFilesData));
 
@@ -583,7 +596,5 @@ class ImportExportScenariosTest extends TestCase
             $this->assertEquals(ImportExportSerializer::decode($currentData, 'json'),
                 ImportExportSerializer::decode($previousData, 'json'));
         }
-
     }
-
 }

--- a/tests/Feature/ScenesTest.php
+++ b/tests/Feature/ScenesTest.php
@@ -248,13 +248,11 @@ class ScenesTest extends TestCase
             ->json('PATCH', '/admin/api/conversation-builder/scenes/' . $fakeScene->getUid(), [
                 'name' => $fakeSceneUpdated->getName(),
                 'id' => $fakeSceneUpdated->getUid(),
-                'od_id' => $fakeSceneUpdated->getODId(),
                 'description' =>  $fakeSceneUpdated->getDescription()
             ])
             //->assertStatus(200)
             ->assertJson([
                 "id" => "0x0001",
-                "od_id" => "welcome_scene",
                 "name" => "Welcome scene updated",
                 "description" => "A welcome scene updated",
                 "interpreter" => "interpreter.core.nlp",

--- a/tests/Feature/TurnsTest.php
+++ b/tests/Feature/TurnsTest.php
@@ -7,11 +7,9 @@ use App\User;
 use Carbon\Carbon;
 use OpenDialogAi\Core\Conversation\BehaviorsCollection;
 use OpenDialogAi\Core\Conversation\ConditionCollection;
-use OpenDialogAi\Core\Conversation\Conversation;
 use OpenDialogAi\Core\Conversation\Exceptions\ConversationObjectNotFoundException;
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
 use OpenDialogAi\Core\Conversation\IntentCollection;
-use OpenDialogAi\Core\Conversation\Scenario;
 use OpenDialogAi\Core\Conversation\Scene;
 use OpenDialogAi\Core\Conversation\Turn;
 use OpenDialogAi\Core\Conversation\TurnCollection;
@@ -262,14 +260,12 @@ class TurnsTest extends TestCase
             ->json('PATCH', '/admin/api/conversation-builder/turns/' . $fakeTurn->getUid(), [
                 'name' => $fakeTurnUpdated->getName(),
                 'id' => $fakeTurnUpdated->getUid(),
-                'od_id' => $fakeTurnUpdated->getOdId(),
                 'description' =>  $fakeTurnUpdated->getDescription(),
                 'valid_origins' => $fakeTurnUpdated->getValidOrigins()
             ])
             //->assertStatus(200)
             ->assertJson([
                 "id" => "0x0004",
-                "od_id" => "welcome_turn_updated",
                 "name" => "Welcome turn updated",
                 "description" => "A welcome turn updated",
                 "interpreter" => "interpreter.core.nlp",

--- a/tests/specification/scenarios/example_scenario.scenario.json
+++ b/tests/specification/scenarios/example_scenario.scenario.json
@@ -4,7 +4,13 @@
     "description": "An example scenario",
     "interpreter": "",
     "behaviors": [],
-    "conditions": [],
+    "conditions": [
+        {
+            "operation": "eq",
+            "operationAttributes": [{"id": "attribute", "value": "selected_scenario"}],
+            "parameters": [{"id": "value", "value": "$path:example_scenario"}]
+        }
+    ],
     "conversations": [
         {
             "od_id": "example_conversation",
@@ -44,7 +50,8 @@
                                     "listens_for" : ["other_example_intent_id"],
                                     "expected_attributes" : [],
                                     "virtual_intents" : [],
-                                    "actions" : []
+                                    "actions" : [],
+                                    "transition": null
                                 }
                             ],
                             "response_intents": [
@@ -61,7 +68,12 @@
                                     "listens_for" : [],
                                     "expected_attributes" : [],
                                     "virtual_intents" : [],
-                                    "actions" : []
+                                    "actions" : [],
+                                    "transition": {
+                                        "conversation": "$path:example_scenario/example_conversation",
+                                        "scene": "$path:example_scenario/example_conversation/example_scene",
+                                        "turn": null
+                                    }
                                 }
                             ]
                         }

--- a/tests/specification/scenarios/example_scenario.scenario.json
+++ b/tests/specification/scenarios/example_scenario.scenario.json
@@ -51,7 +51,11 @@
                                     "expected_attributes" : [],
                                     "virtual_intents" : [],
                                     "actions" : [],
-                                    "transition": null
+                                    "transition": {
+                                        "conversation": null,
+                                        "scene": null,
+                                        "turn": null
+                                    }
                                 }
                             ],
                             "response_intents": [


### PR DESCRIPTION
This PR fixes a bug in which transitions & conditions were not properly exported/imported. This PR is dependent on https://github.com/opendialogai/core/pull/481.

The bug was that references to other conversation objects rely on graph UIDs, which are not consistent across different OpenDialog instances. The fix was to replace such UID's with a new path string at export time, and to replace that path string with new UID's at import time.

The structure of a path string is as follows:

`$path:[scenario_id]/[conversation_id]/[scene_id]/[turn_id]`

Each component ID is optional, as such a full string (as above) represents a turn, whereas `$path:[scenario_id]` simply represents a scenario.

To ensure that path strings could be relied upon to uniquely represent objects, a new API validation rule has been added to ensure that OD ID's are unique with their parent scope. This means, for example, that you can't have two scenes with the same ID within the same conversation, but you could if those scenes were in separate conversations.