### PR TITLE
Adding endpoint to query interpreters by scenario

### DIFF
--- a/app/Http/Controllers/API/ComponentConfigurationController.php
+++ b/app/Http/Controllers/API/ComponentConfigurationController.php
@@ -3,13 +3,16 @@
 namespace App\Http\Controllers\API;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\ComponentConfigurationQueryRequest;
 use App\Http\Requests\ComponentConfigurationRequest;
 use App\Http\Requests\ComponentConfigurationTestRequest;
 use App\Http\Resources\ComponentConfigurationCollection;
 use App\Http\Resources\ComponentConfigurationResource;
+use App\Http\Resources\ScenarioResource;
 use Illuminate\Http\Response;
 use OpenDialogAi\AttributeEngine\CoreAttributes\UtteranceAttribute;
 use OpenDialogAi\Core\Components\Configuration\ComponentConfiguration;
+use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
 use OpenDialogAi\InterpreterEngine\Service\InterpreterComponentServiceInterface;
 
 class ComponentConfigurationController extends Controller
@@ -95,5 +98,18 @@ class ComponentConfigurationController extends Controller
 
         $status = $intents->isEmpty() ? 400 : 200;
         return response(null, $status);
+    }
+
+    /**
+     * Allows for querying of a configuration across all conversation objects
+     *
+     * @param ComponentConfigurationQueryRequest $request
+     * @return ScenarioResource|Response
+     */
+    public function query(ComponentConfigurationQueryRequest $request)
+    {
+        $scenarios = ConversationDataClient::getScenariosWhereInterpreterEquals($request->get('name'));
+
+        return new ScenarioResource($scenarios);
     }
 }

--- a/app/Http/Requests/ComponentConfigurationQueryRequest.php
+++ b/app/Http/Requests/ComponentConfigurationQueryRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ComponentConfigurationQueryRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => [
+                'required',
+                'bail',
+                'string',
+                'filled',
+                'exists:component_configurations,name'
+            ],
+        ];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "laravel/tinker": "^2.0",
         "laravel/ui": "^3.0",
         "maennchen/zipstream-php": "^2.0",
-        "opendialogai/core": "dev-feature/query-per-scenario",
+        "opendialogai/core": "1.x-dev",
         "opendialogai/dgraph-docker": "20.11.0",
         "opendialogai/webchat": "1.x-dev",
         "phalcongelist/php-diff": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "laravel/tinker": "^2.0",
         "laravel/ui": "^3.0",
         "maennchen/zipstream-php": "^2.0",
-        "opendialogai/core": "1.x-dev",
+        "opendialogai/core": "dev-feature/query-per-scenario",
         "opendialogai/dgraph-docker": "20.11.0",
         "opendialogai/webchat": "1.x-dev",
         "phalcongelist/php-diff": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf2e735bb84f7be4052cbe2be1a17b05",
+    "content-hash": "fe3c77b1387348bb288ff8b87d2e2757",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3232,16 +3232,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "dev-feature/query-per-scenario",
+            "version": "1.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "f0485f94d43f001842883e491df7c69e77f4a68c"
+                "reference": "eb8da6c89a2be167cc67108a6ed20bc2c784d2c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/f0485f94d43f001842883e491df7c69e77f4a68c",
-                "reference": "f0485f94d43f001842883e491df7c69e77f4a68c",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/eb8da6c89a2be167cc67108a6ed20bc2c784d2c0",
+                "reference": "eb8da6c89a2be167cc67108a6ed20bc2c784d2c0",
                 "shasum": ""
             },
             "require": {
@@ -3269,6 +3269,7 @@
                 "phpunit/phpunit": "^9.0",
                 "squizlabs/php_codesniffer": "^3.4"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -3320,9 +3321,9 @@
             "description": "The OpenDialog Core package",
             "support": {
                 "issues": "https://github.com/opendialogai/core/issues",
-                "source": "https://github.com/opendialogai/core/tree/feature/query-per-scenario"
+                "source": "https://github.com/opendialogai/core/tree/1.x"
             },
-            "time": "2021-05-25T10:52:21+00:00"
+            "time": "2021-05-26T11:02:14+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fe3c77b1387348bb288ff8b87d2e2757",
+    "content-hash": "cf2e735bb84f7be4052cbe2be1a17b05",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3232,16 +3232,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "1.x-dev",
+            "version": "dev-feature/query-per-scenario",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "eb901901fd80b48f31404e988c2ee58ba79a5782"
+                "reference": "f0485f94d43f001842883e491df7c69e77f4a68c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/eb901901fd80b48f31404e988c2ee58ba79a5782",
-                "reference": "eb901901fd80b48f31404e988c2ee58ba79a5782",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/f0485f94d43f001842883e491df7c69e77f4a68c",
+                "reference": "f0485f94d43f001842883e491df7c69e77f4a68c",
                 "shasum": ""
             },
             "require": {
@@ -3269,7 +3269,6 @@
                 "phpunit/phpunit": "^9.0",
                 "squizlabs/php_codesniffer": "^3.4"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -3321,9 +3320,9 @@
             "description": "The OpenDialog Core package",
             "support": {
                 "issues": "https://github.com/opendialogai/core/issues",
-                "source": "https://github.com/opendialogai/core/tree/1.x"
+                "source": "https://github.com/opendialogai/core/tree/feature/query-per-scenario"
             },
-            "time": "2021-05-24T16:32:07+00:00"
+            "time": "2021-05-25T10:52:21+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/routes/api.php
+++ b/routes/api.php
@@ -53,6 +53,7 @@ Route::namespace('API')
 
         Route::apiResource('component-configuration', 'ComponentConfigurationController');
         Route::post('component-configurations/test', 'ComponentConfigurationController@test');
+        Route::post('component-configurations/query', 'ComponentConfigurationController@query');
 
         Route::get('dynamic-attributes/download', 'DynamicAttributesController@download');
         Route::post('dynamic-attributes/upload', 'DynamicAttributesController@upload');


### PR DESCRIPTION
This PR is dependent on https://github.com/opendialogai/core/pull/493, and adds an endpoint which takes input of an interpreter configuration name and returns a list of scenarios in which it is in use.