### PR TITLE
Upgrade to DGraph 21.03.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "laravel/ui": "^3.0",
         "maennchen/zipstream-php": "^2.0",
         "opendialogai/core": "1.x-dev",
-        "opendialogai/dgraph-docker": "21.03.0-rc.0",
+        "opendialogai/dgraph-docker": "21.03.0",
         "opendialogai/webchat": "1.x-dev",
         "phalcongelist/php-diff": "^2.0",
         "predis/predis": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "laravel/ui": "^3.0",
         "maennchen/zipstream-php": "^2.0",
         "opendialogai/core": "1.x-dev",
-        "opendialogai/dgraph-docker": "20.11.0",
+        "opendialogai/dgraph-docker": "21.03.0-rc.0",
         "opendialogai/webchat": "1.x-dev",
         "phalcongelist/php-diff": "^2.0",
         "predis/predis": "^1.1",

--- a/od-docker-demo/docker-compose.yml
+++ b/od-docker-demo/docker-compose.yml
@@ -16,7 +16,6 @@ services:
     depends_on:
       - mysql
       - dgraph-server
-      - dgraph-ratel
       - dgraph-zero
   mysql:
     image: mysql:5.7.27
@@ -36,7 +35,7 @@ services:
     networks:
       - app-network
   dgraph-zero:
-    image: dgraph/dgraph:v20.11.0
+    image: dgraph/dgraph:v21.03.0
     volumes:
       - type: volume
         source: dgraph
@@ -53,7 +52,7 @@ services:
     links:
       - dgraph-server
   dgraph-server:
-    image: dgraph/dgraph:v20.11.0
+    image: dgraph/dgraph:v21.03.0
     volumes:
       - type: volume
         source: dgraph
@@ -64,22 +63,9 @@ services:
       - 8080:8080
       - 9080:9080
     restart: on-failure
-    command: dgraph alpha --auth_token=dgraphauthsecrettoken --whitelist 0.0.0.0/0 --my=dgraph-server:7080 --lru_mb=2048 --zero=dgraph-zero:5080
+    command: dgraph alpha --security token=dgraphauthsecrettoken --security whitelist=0.0.0.0/0 --my=dgraph-server:7080 --zero=dgraph-zero:5080
     networks:
       - app-network
-  dgraph-ratel:
-    image: dgraph/dgraph:v20.11.0
-    ports:
-      - 9001:8000
-    volumes:
-      - type: volume
-        source: dgraph
-        target: /dgraph
-        volume:
-          nocopy: true
-    networks:
-      - app-network
-    command: dgraph-ratel
 
 networks:
   app-network:


### PR DESCRIPTION
This PR upgrades the version of DGraph used with OpenDialog to the latest 21.03.0 version