### PR TITLE
Updates the config keys used in the status endpoint

### DIFF
--- a/app/Http/Controllers/StatusController.php
+++ b/app/Http/Controllers/StatusController.php
@@ -64,8 +64,8 @@ class StatusController extends Controller
      */
     private function checkDgraphStatus()
     {
-        $dgraphUrl = config('opendialog.core.DGRAPH_URL');
-        $dGraphPort = config('opendialog.core.DGRAPH_PORT');
+        $dgraphUrl = config('opendialog.graphql.DGRAPH_BASE_URL');
+        $dGraphPort = config('opendialog.graphql.DGRAPH_PORT');
 
         $client = new Client([
             'base_uri' => $dgraphUrl . ":" . $dGraphPort


### PR DESCRIPTION
The status endpoint was erroring with a 500 as it was using the wrong config keys to get try to connect to DGraph.

This update ensures that the status endpoint works