### PR TITLE
Updating simulator API to use turn_status

### DIFF
--- a/app/Http/Controllers/API/ConversationSimulationController.php
+++ b/app/Http/Controllers/API/ConversationSimulationController.php
@@ -17,7 +17,7 @@ class ConversationSimulationController extends Controller
 {
     public function simulate(SimulationRequest $request)
     {
-        $conversationalState = (new ConversationalState($request->json('speaker'), $request->json('intent_is_request')))
+        $conversationalState = (new ConversationalState($request->json('speaker'), $request->json('turn_status')))
             ->setScenarioId($request->json('scenario') ?? Scenario::UNDEFINED)
             ->setConversationId($request->json('conversation') ?? Conversation::UNDEFINED)
             ->setSceneId($request->json('scene') ?? Scene::UNDEFINED)

--- a/app/Http/Requests/SimulationRequest.php
+++ b/app/Http/Requests/SimulationRequest.php
@@ -3,8 +3,10 @@
 
 namespace App\Http\Requests;
 
-use App\Rules\Status;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use OpenDialogAi\ConversationEngine\Util\ConversationalState;
+use OpenDialogAi\Core\Conversation\Intent;
 
 class SimulationRequest extends FormRequest
 {
@@ -31,8 +33,8 @@ class SimulationRequest extends FormRequest
             "scene" => "string|nullable",
             "turn" => "string|nullable",
             "intent" => "string|nullable",
-            "speaker" => "required|string",
-            "intent_is_request" => "required|boolean",
+            "speaker" => ['required', 'string', Rule::in(Intent::VALID_SPEAKERS)],
+            "turn_status" => ['required', 'string', Rule::in(ConversationalState::VALID_TURN_STATUSES)],
         ];
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "laravel/tinker": "^2.0",
         "laravel/ui": "^3.0",
         "maennchen/zipstream-php": "^2.0",
-        "opendialogai/core": "1.x-dev",
+        "opendialogai/core": "dev-feature/OPNDLG-715--turn-status",
         "opendialogai/dgraph-docker": "21.03.0",
         "opendialogai/webchat": "1.x-dev",
         "phalcongelist/php-diff": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "laravel/tinker": "^2.0",
         "laravel/ui": "^3.0",
         "maennchen/zipstream-php": "^2.0",
-        "opendialogai/core": "dev-feature/OPNDLG-715--turn-transitions",
+        "opendialogai/core": "1.x-dev",
         "opendialogai/dgraph-docker": "21.03.0",
         "opendialogai/webchat": "1.x-dev",
         "phalcongelist/php-diff": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "laravel/tinker": "^2.0",
         "laravel/ui": "^3.0",
         "maennchen/zipstream-php": "^2.0",
-        "opendialogai/core": "dev-feature/OPNDLG-715--turn-status",
+        "opendialogai/core": "dev-feature/OPNDLG-715--turn-transitions",
         "opendialogai/dgraph-docker": "21.03.0",
         "opendialogai/webchat": "1.x-dev",
         "phalcongelist/php-diff": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ac211dafea025c5f405bc9c858df5887",
+    "content-hash": "2f29053b455306c95145e41fe706cf59",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2937,16 +2937,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "1.x-dev",
+            "version": "dev-feature/OPNDLG-715--turn-status",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "4bf4229850c3b9883b53efed47a3656e8541f856"
+                "reference": "4177a47ff63eb547649d3a270245594054f98704"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/4bf4229850c3b9883b53efed47a3656e8541f856",
-                "reference": "4bf4229850c3b9883b53efed47a3656e8541f856",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/4177a47ff63eb547649d3a270245594054f98704",
+                "reference": "4177a47ff63eb547649d3a270245594054f98704",
                 "shasum": ""
             },
             "require": {
@@ -2968,12 +2968,11 @@
                 "friendsofphp/php-cs-fixer": "^2.15",
                 "matthewbdaly/artisan-standalone": "^0.0.8",
                 "mockery/mockery": "^1.2",
-                "opendialogai/dgraph-docker": "^20.11.0",
+                "opendialogai/dgraph-docker": "^21.03.0",
                 "orchestra/testbench": "^6.0",
                 "phpunit/phpunit": "^9.0",
                 "squizlabs/php_codesniffer": "^3.4"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -3023,9 +3022,9 @@
             "description": "The OpenDialog Core package",
             "support": {
                 "issues": "https://github.com/opendialogai/core/issues",
-                "source": "https://github.com/opendialogai/core/tree/rc/1.0.0-alpha"
+                "source": "https://github.com/opendialogai/core/tree/feature/OPNDLG-715--turn-status"
             },
-            "time": "2021-06-08T14:32:14+00:00"
+            "time": "2021-06-10T13:11:10+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2f29053b455306c95145e41fe706cf59",
+    "content-hash": "3b55aa309da04318a3f48fa764972757",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2937,16 +2937,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "dev-feature/OPNDLG-715--turn-status",
+            "version": "dev-feature/OPNDLG-715--turn-transitions",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "4177a47ff63eb547649d3a270245594054f98704"
+                "reference": "04b9fac9e543b5fc027511051084211f9c6d54c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/4177a47ff63eb547649d3a270245594054f98704",
-                "reference": "4177a47ff63eb547649d3a270245594054f98704",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/04b9fac9e543b5fc027511051084211f9c6d54c1",
+                "reference": "04b9fac9e543b5fc027511051084211f9c6d54c1",
                 "shasum": ""
             },
             "require": {
@@ -3022,9 +3022,9 @@
             "description": "The OpenDialog Core package",
             "support": {
                 "issues": "https://github.com/opendialogai/core/issues",
-                "source": "https://github.com/opendialogai/core/tree/feature/OPNDLG-715--turn-status"
+                "source": "https://github.com/opendialogai/core/tree/feature/OPNDLG-715--turn-transitions"
             },
-            "time": "2021-06-10T13:11:10+00:00"
+            "time": "2021-06-14T11:45:44+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3b55aa309da04318a3f48fa764972757",
+    "content-hash": "ac211dafea025c5f405bc9c858df5887",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2937,16 +2937,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "dev-feature/OPNDLG-715--turn-transitions",
+            "version": "1.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "04b9fac9e543b5fc027511051084211f9c6d54c1"
+                "reference": "e62fe4238dec8801fe4f6786b4bb5da1c6f66817"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/04b9fac9e543b5fc027511051084211f9c6d54c1",
-                "reference": "04b9fac9e543b5fc027511051084211f9c6d54c1",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/e62fe4238dec8801fe4f6786b4bb5da1c6f66817",
+                "reference": "e62fe4238dec8801fe4f6786b4bb5da1c6f66817",
                 "shasum": ""
             },
             "require": {
@@ -2973,6 +2973,7 @@
                 "phpunit/phpunit": "^9.0",
                 "squizlabs/php_codesniffer": "^3.4"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -3022,9 +3023,9 @@
             "description": "The OpenDialog Core package",
             "support": {
                 "issues": "https://github.com/opendialogai/core/issues",
-                "source": "https://github.com/opendialogai/core/tree/feature/OPNDLG-715--turn-transitions"
+                "source": "https://github.com/opendialogai/core/tree/1.x"
             },
-            "time": "2021-06-14T11:45:44+00:00"
+            "time": "2021-06-15T10:44:43+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/tests/Feature/ConversationSimulatorTest.php
+++ b/tests/Feature/ConversationSimulatorTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\User;
+use OpenDialogAi\ConversationEngine\Facades\Selectors\ConversationSelector;
+use OpenDialogAi\ConversationEngine\Facades\Selectors\IntentSelector;
+use OpenDialogAi\ConversationEngine\Facades\Selectors\ScenarioSelector;
+use OpenDialogAi\ConversationEngine\Facades\Selectors\SceneSelector;
+use OpenDialogAi\ConversationEngine\Facades\Selectors\TurnSelector;
+use OpenDialogAi\ConversationEngine\Util\ConversationalState;
+use OpenDialogAi\Core\Conversation\ConversationCollection;
+use OpenDialogAi\Core\Conversation\Intent;
+use OpenDialogAi\Core\Conversation\IntentCollection;
+use OpenDialogAi\Core\Conversation\ScenarioCollection;
+use OpenDialogAi\Core\Conversation\SceneCollection;
+use OpenDialogAi\Core\Conversation\TurnCollection;
+use Tests\TestCase;
+
+class ConversationSimulatorTest extends TestCase
+{
+    public function testSuccess()
+    {
+        $this->mockSelectors();
+
+        $user = factory(User::class)->create();
+
+        $this->actingAs($user, 'api')
+            ->json('POST', '/admin/api/conversation-simulation', [
+                "scenario" => null,
+                "conversation" => null,
+                "scene" => null,
+                "turn" => null,
+                "intent" => null,
+                "speaker" => Intent::APP,
+                "turn_status" => ConversationalState::OUT_OF_TURN,
+            ])
+            ->assertStatus(200);
+    }
+
+    public function testFailure()
+    {
+        $user = factory(User::class)->create();
+
+        $this->actingAs($user, 'api')
+            ->json('POST', '/admin/api/conversation-simulation', [
+                "scenario" => null,
+                "conversation" => null,
+                "scene" => null,
+                "turn" => null,
+                "intent" => null,
+                "speaker" => Intent::APP,
+                "turn_status" => 'unknown',
+            ])
+            ->assertStatus(422);
+    }
+
+    protected function mockSelectors(): void
+    {
+        ScenarioSelector::shouldReceive('selectScenarios')
+            ->once()
+            ->andReturn(new ScenarioCollection());
+        ScenarioSelector::makePartial();
+
+        ConversationSelector::shouldReceive('selectStartingConversations')
+            ->once()
+            ->andReturn(new ConversationCollection());
+        ConversationSelector::makePartial();
+
+        SceneSelector::shouldReceive('selectStartingScenes')
+            ->once()
+            ->andReturn(new SceneCollection());
+        SceneSelector::makePartial();
+
+        TurnSelector::shouldReceive('selectStartingTurns')
+            ->once()
+            ->andReturn(new TurnCollection());
+        TurnSelector::makePartial();
+
+        IntentSelector::shouldReceive('selectRequestIntents')
+            ->once()
+            ->andReturn(new IntentCollection());
+        IntentSelector::makePartial();
+    }
+}


### PR DESCRIPTION
This PR is dependent on https://github.com/opendialogai/core/pull/513 & https://github.com/opendialogai/opendialog-design-system/pull/147. It updates uses of `intent_is_request` boolean field to a `turn_status` string psuedo-enum.