### PR TITLE
Database sessions

### DIFF
--- a/database/migrations/2021_06_14_115316_create_sessions_table.php
+++ b/database/migrations/2021_06_14_115316_create_sessions_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateSessionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('sessions', function (Blueprint $table) {
+            $table->string('id')->primary();
+            $table->foreignId('user_id')->nullable()->index();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->text('payload');
+            $table->integer('last_activity')->index();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('sessions');
+    }
+}


### PR DESCRIPTION
This PR includes the migration file to allow sessions to be stored in the database. Once the migration has been run, the app's `env` file can be updated to set the value of `SESSION_DRIVER` to `database`

Sessions are cleared from the database automatically by Laravel garbage collection 