### PR TITLE
DGraph version update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "laravel/ui": "^3.0",
         "maennchen/zipstream-php": "^2.0",
         "opendialogai/core": "1.x-dev",
-        "opendialogai/dgraph-docker": "21.03.0",
+        "opendialogai/dgraph-docker": "21.03.0.2",
         "opendialogai/webchat": "1.x-dev",
         "phalcongelist/php-diff": "^2.0",
         "predis/predis": "^1.1",

--- a/od-docker-demo/docker-compose.yml
+++ b/od-docker-demo/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     networks:
       - app-network
   dgraph-zero:
-    image: dgraph/dgraph:v21.03.0
+    image: dgraph/dgraph:v21.03.0-12-g44005bc82
     volumes:
       - type: volume
         source: dgraph
@@ -52,7 +52,7 @@ services:
     links:
       - dgraph-server
   dgraph-server:
-    image: dgraph/dgraph:v21.03.0
+    image: dgraph/dgraph:v21.03.0-12-g44005bc82
     volumes:
       - type: volume
         source: dgraph


### PR DESCRIPTION
This PR updates the version of dgraph used for the od-docker-demo and as part of dgraph-docker for running ci tests.

This version of DGraph includes a fix that better supports the use of reverse predicates - https://github.com/dgraph-io/dgraph/commit/00ada83

Fixes #317