### PR TITLE
Feature/opndlg 824 url validation

### DIFF
--- a/app/Http/Requests/ComponentConfigurationRequest.php
+++ b/app/Http/Requests/ComponentConfigurationRequest.php
@@ -4,6 +4,8 @@ namespace App\Http\Requests;
 
 use App\Rules\ComponentConfigurationRule;
 use App\Rules\ComponentRegistrationRule;
+use App\Rules\PublicUrlRule;
+use App\Rules\UrlSchemeRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -46,6 +48,16 @@ class ComponentConfigurationRequest extends FormRequest
                 Rule::requiredIf($this->method() == 'POST' || !is_null($this->get('component_id'))),
                 'array',
                 new ComponentConfigurationRule($this->get('component_id', ''))
+            ],
+            'configuration.app_url' => [
+                'active_url',
+                new PublicUrlRule,
+                new UrlSchemeRule
+            ],
+            'configuration.webhook_url' => [
+                'active_url',
+                new PublicUrlRule,
+                new UrlSchemeRule
             ],
             'active' => [
                 'bail',

--- a/app/Http/Requests/ComponentConfigurationRequest.php
+++ b/app/Http/Requests/ComponentConfigurationRequest.php
@@ -28,7 +28,7 @@ class ComponentConfigurationRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
+        $rules = [
             'name' => [
                 Rule::requiredIf($this->method() == 'POST'),
                 'bail',
@@ -49,20 +49,27 @@ class ComponentConfigurationRequest extends FormRequest
                 'array',
                 new ComponentConfigurationRule($this->get('component_id', ''))
             ],
-            'configuration.app_url' => [
-                'active_url',
-                new PublicUrlRule,
-                new UrlSchemeRule
-            ],
-            'configuration.webhook_url' => [
-                'active_url',
-                new PublicUrlRule,
-                new UrlSchemeRule
-            ],
             'active' => [
                 'bail',
                 'boolean',
             ]
         ];
+
+        // Only set the URL validation rules if we are not in debug mode to allow local URLs during local development
+        if (config('app.env') !== 'local') {
+            $rules['configuration.app_url'] = [
+                'active_url',
+                new PublicUrlRule,
+                new UrlSchemeRule
+            ];
+
+            $rules['configuration.webhook_url'] = [
+                'active_url',
+                new PublicUrlRule,
+                new UrlSchemeRule
+            ];
+        }
+
+        return $rules;
     }
 }

--- a/app/Http/Requests/ComponentConfigurationTestRequest.php
+++ b/app/Http/Requests/ComponentConfigurationTestRequest.php
@@ -16,6 +16,8 @@ class ComponentConfigurationTestRequest extends ComponentConfigurationRequest
         $rules = [];
         $rules['component_id'] = $originalRules['component_id'];
         $rules['configuration'] = $originalRules['configuration'];
+        $rules['configuration.app_url'] = $originalRules['configuration.app_url'];
+        $rules['configuration.webhook_url'] = $originalRules['configuration.webhook_url'];
 
         return $rules;
     }

--- a/app/Rules/PublicUrlRule.php
+++ b/app/Rules/PublicUrlRule.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class PublicUrlRule implements Rule
+{
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        $result = parse_url($value);
+        $path = isset($result['host']) ? strtolower($result['host']) : $result['path'];
+
+        $ip = gethostbyname($path);
+        return filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_NO_PRIV_RANGE |  FILTER_FLAG_NO_RES_RANGE);
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'The URL used is not valid or points to a private IP.';
+    }
+}

--- a/app/Rules/UrlSchemeRule.php
+++ b/app/Rules/UrlSchemeRule.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class UrlSchemeRule implements Rule
+{
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        $result = parse_url($value);
+        $scheme = isset($result['scheme']) ? strtolower($result['scheme']) : null;
+
+        return in_array($scheme, ['http', 'https']);
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'The provided URL is not http or https scheme.';
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "laravel/tinker": "^2.0",
         "laravel/ui": "^3.0",
         "maennchen/zipstream-php": "^2.0",
-        "opendialogai/core": "1.x-dev",
+        "opendialogai/core": "dev-feature/OPNDLG-824_url_validation",
         "opendialogai/dgraph-docker": "21.03.0.2",
         "opendialogai/webchat": "1.x-dev",
         "phalcongelist/php-diff": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6ca1747337a65d7aa514fe6692f0127c",
+    "content-hash": "6f9dcda66fb7eba5d3c1f052a5aea9da",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2937,16 +2937,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "1.x-dev",
+            "version": "dev-feature/OPNDLG-824_url_validation",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "cda487b159582b242c8252b87f788cb27e5af37c"
+                "reference": "9dbe42561bd9fa4d4c0e56c136f90e359eb00f9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/cda487b159582b242c8252b87f788cb27e5af37c",
-                "reference": "cda487b159582b242c8252b87f788cb27e5af37c",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/9dbe42561bd9fa4d4c0e56c136f90e359eb00f9d",
+                "reference": "9dbe42561bd9fa4d4c0e56c136f90e359eb00f9d",
                 "shasum": ""
             },
             "require": {
@@ -2973,7 +2973,6 @@
                 "phpunit/phpunit": "^9.0",
                 "squizlabs/php_codesniffer": "^3.4"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -3023,9 +3022,9 @@
             "description": "The OpenDialog Core package",
             "support": {
                 "issues": "https://github.com/opendialogai/core/issues",
-                "source": "https://github.com/opendialogai/core/tree/1.x"
+                "source": "https://github.com/opendialogai/core/tree/feature/OPNDLG-824_url_validation"
             },
-            "time": "2021-06-15T16:44:42+00:00"
+            "time": "2021-06-17T11:15:01+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/tests/Feature/ComponentConfigurationTest.php
+++ b/tests/Feature/ComponentConfigurationTest.php
@@ -240,6 +240,25 @@ class ComponentConfigurationTest extends TestCase
             ->assertJsonValidationErrors(['configuration.app_url']);
     }
 
+    public function testStoreInvalidAppUrlLocalEnv()
+    {
+        $this->app['config']->set('app.env', 'local');
+
+        $data = [
+            'name' => 'My New Name',
+            'component_id' => 'interpreter.core.luis',
+            'configuration' => [
+                LuisInterpreterConfiguration::APP_URL => 'file://example.com/', //invalid scheme
+                LuisInterpreterConfiguration::APP_ID => '123',
+            ],
+        ];
+
+        $this->actingAs($this->user, 'api')
+            ->json('POST', '/admin/api/component-configuration/', $data)
+            ->assertStatus(422)
+            ->assertJsonMissingValidationErrors(['configuration.app_url']);
+    }
+
     public function testStoreInvalidWebhookUrl()
     {
         $data = [
@@ -254,6 +273,23 @@ class ComponentConfigurationTest extends TestCase
             ->json('POST', '/admin/api/component-configuration/', $data)
             ->assertStatus(422)
             ->assertJsonValidationErrors(['configuration.webhook_url']);
+    }
+
+    public function testStoreInvalidWebhookUrlLocalEnv()
+    {
+        $this->app['config']->set('app.env', 'local');
+
+        $data = [
+            'name' => 'Bad webhook',
+            'component_id' => 'action.core.webhook',
+            'configuration' => [
+                'webhook_url' => 'localhost'
+            ],
+        ];
+
+        $this->actingAs($this->user, 'api')
+            ->json('POST', '/admin/api/component-configuration/', $data)
+            ->assertJsonMissingValidationErrors(['configuration.webhook_url']);
     }
 
     public function testDestroy()
@@ -320,6 +356,24 @@ class ComponentConfigurationTest extends TestCase
             ->json('POST', '/admin/api/component-configurations/test', $data)
             ->assertStatus(422)
             ->assertJsonValidationErrors(['configuration.app_url']);
+    }
+
+    public function testTestConfigurationInvalidUrlLocalEnv()
+    {
+        $this->app['config']->set('app.env', 'local');
+
+        $data = [
+            'name' => 'My New Name',
+            'component_id' => 'interpreter.core.luis',
+            'configuration' => [
+                LuisInterpreterConfiguration::APP_URL => 'file://example.com/', //invalid scheme
+                LuisInterpreterConfiguration::APP_ID => '123',
+            ],
+        ];
+
+        $this->actingAs($this->user, 'api')
+            ->json('POST', '/admin/api/component-configurations/test', $data)
+            ->assertJsonMissingValidationErrors(['configuration.app_url']);
     }
 
     public function testTestConfigurationFailureNoResponseFromProvider()

--- a/tests/Feature/ComponentConfigurationTest.php
+++ b/tests/Feature/ComponentConfigurationTest.php
@@ -223,6 +223,39 @@ class ComponentConfigurationTest extends TestCase
             ->assertJsonValidationErrors(['configuration']);
     }
 
+    public function testStoreInvalidAppUrl()
+    {
+        $data = [
+            'name' => 'My New Name',
+            'component_id' => 'interpreter.core.luis',
+            'configuration' => [
+                LuisInterpreterConfiguration::APP_URL => 'file://example.com/', //invalid scheme
+                LuisInterpreterConfiguration::APP_ID => '123',
+            ],
+        ];
+
+        $this->actingAs($this->user, 'api')
+            ->json('POST', '/admin/api/component-configuration/', $data)
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['configuration.app_url']);
+    }
+
+    public function testStoreInvalidWebhookUrl()
+    {
+        $data = [
+            'name' => 'Bad webhook',
+            'component_id' => 'action.core.webhook',
+            'configuration' => [
+                'webhook_url' => 'localhost'
+            ],
+        ];
+
+        $this->actingAs($this->user, 'api')
+            ->json('POST', '/admin/api/component-configuration/', $data)
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['configuration.webhook_url']);
+    }
+
     public function testDestroy()
     {
         /** @var ComponentConfiguration $configuration */
@@ -270,6 +303,23 @@ class ComponentConfigurationTest extends TestCase
             ->json('POST', '/admin/api/component-configurations/test', $data)
             ->assertStatus(422)
             ->assertJsonValidationErrors(['component_id']);
+    }
+
+    public function testTestConfigurationFailureInvalidUrl()
+    {
+        $data = [
+            'name' => 'My New Name',
+            'component_id' => 'interpreter.core.luis',
+            'configuration' => [
+                LuisInterpreterConfiguration::APP_URL => 'file://example.com/', //invalid scheme
+                LuisInterpreterConfiguration::APP_ID => '123',
+            ],
+        ];
+
+        $this->actingAs($this->user, 'api')
+            ->json('POST', '/admin/api/component-configurations/test', $data)
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['configuration.app_url']);
     }
 
     public function testTestConfigurationFailureNoResponseFromProvider()

--- a/tests/Unit/UrlTest.php
+++ b/tests/Unit/UrlTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Rules\PublicUrlRule;
+use App\Rules\UrlSchemeRule;
+use Illuminate\Support\Facades\Validator;
+use Tests\TestCase;
+
+class UrlTest extends TestCase
+{
+    public function testUrls()
+    {
+        $tests = [
+            'www.google.com' => false,
+            'http://www.google.com' => true,
+            'https://www.google.com' => true,
+            '127.0.0.1' => false,
+            'localhost' => false,
+            'http://localhost' => false,
+            'http://cloud.opendialog.dev' => false,
+            'http://10.0.0.2' => false,
+            'http://192.168.0.1' => false,
+            'http://216.0x3a.0000326.0xe3' => false,
+            'https://lisaqna.azurewebsites.net/qnamaker/knowledgebases/xx/generateAnswer' => true,
+        ];
+
+        foreach ($tests as $url => $shouldPass) {
+            $this->urlRuleTester($url, $shouldPass);
+        }
+    }
+
+    private function urlRuleTester($url, $shouldPass)
+    {
+        $validator = Validator::make(['url' => $url], [
+            'url' => ['active_url', new PublicUrlRule, new UrlSchemeRule]
+        ]);
+
+        $passes = $validator->passes();
+
+        if ($shouldPass) {
+            $errorMessages = $validator->errors()->getMessages() ? implode(",", $validator->errors()->getMessages()['url']) : "";
+            $this->assertTrue(
+                $passes,
+                sprintf(
+                    'URL %s should have passed, but failed with these messages %s',
+                    $url,
+                    $errorMessages
+                )
+            );
+        } else {
+            $this->assertFalse($passes, sprintf('URL %s should have failed, but passed', $url));
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses some issues around letting users enter any URL into the component configuration for interpreters and actions.

This is potentially unsafe as the URL provided could resolve locally or try to do something malicious.

The existing request class has been updated to optionally add some rules around `app_url` (for interpreters) and `webhook_url` (for webhook action) that will check it the URL can be resolved, whether it points to a private IP address and whether it is using the HTTP or HTTPS sheme. The configuration will be disallowed if it meets any of these.

Since interpreters such as RASA and webhook URLs might well be local URLs whilst in development, the rules are conditionally added only if the config value for `app.env` is anything other than `local`

This PR also goes together with https://github.com/opendialogai/core/pull/518 which ensure that the HTTP client used to make these requests doesn't follow redirects rendering these checks invald 