### PR TITLE
Updating default conversations to include a trigger conversation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "laravel/tinker": "^2.0",
         "laravel/ui": "^3.0",
         "maennchen/zipstream-php": "^2.0",
-        "opendialogai/core": "dev-fix/OPNDLG-846_button_message_value_validation",
+        "opendialogai/core": "1.x-dev",
         "opendialogai/dgraph-docker": "21.03.0.2",
         "opendialogai/webchat": "1.x-dev",
         "phalcongelist/php-diff": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "laravel/tinker": "^2.0",
         "laravel/ui": "^3.0",
         "maennchen/zipstream-php": "^2.0",
-        "opendialogai/core": "dev-feature/OPNDLG-832--default-trigger-conversation",
+        "opendialogai/core": "dev-fix/OPNDLG-846_button_message_value_validation",
         "opendialogai/dgraph-docker": "21.03.0.2",
         "opendialogai/webchat": "1.x-dev",
         "phalcongelist/php-diff": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "laravel/tinker": "^2.0",
         "laravel/ui": "^3.0",
         "maennchen/zipstream-php": "^2.0",
-        "opendialogai/core": "1.x-dev",
+        "opendialogai/core": "dev-feature/OPNDLG-832--default-trigger-conversation",
         "opendialogai/dgraph-docker": "21.03.0.2",
         "opendialogai/webchat": "1.x-dev",
         "phalcongelist/php-diff": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6ca1747337a65d7aa514fe6692f0127c",
+    "content-hash": "9e076c83696444d4da8875876c1e8d17",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2937,16 +2937,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "1.x-dev",
+            "version": "dev-feature/OPNDLG-832--default-trigger-conversation",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "cda487b159582b242c8252b87f788cb27e5af37c"
+                "reference": "b5879e7505f95325b6276612236eff90ecc35465"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/cda487b159582b242c8252b87f788cb27e5af37c",
-                "reference": "cda487b159582b242c8252b87f788cb27e5af37c",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/b5879e7505f95325b6276612236eff90ecc35465",
+                "reference": "b5879e7505f95325b6276612236eff90ecc35465",
                 "shasum": ""
             },
             "require": {
@@ -2973,7 +2973,6 @@
                 "phpunit/phpunit": "^9.0",
                 "squizlabs/php_codesniffer": "^3.4"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -3023,9 +3022,9 @@
             "description": "The OpenDialog Core package",
             "support": {
                 "issues": "https://github.com/opendialogai/core/issues",
-                "source": "https://github.com/opendialogai/core/tree/1.x"
+                "source": "https://github.com/opendialogai/core/tree/feature/OPNDLG-832--default-trigger-conversation"
             },
-            "time": "2021-06-15T16:44:42+00:00"
+            "time": "2021-06-16T16:41:28+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9e076c83696444d4da8875876c1e8d17",
+    "content-hash": "5ceded86dad9a5591acad681fc3ec263",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2937,16 +2937,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "dev-feature/OPNDLG-832--default-trigger-conversation",
+            "version": "dev-fix/OPNDLG-846_button_message_value_validation",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "b5879e7505f95325b6276612236eff90ecc35465"
+                "reference": "b7dd2d90037ef1749e365a810180887e6ab5c33f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/b5879e7505f95325b6276612236eff90ecc35465",
-                "reference": "b5879e7505f95325b6276612236eff90ecc35465",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/b7dd2d90037ef1749e365a810180887e6ab5c33f",
+                "reference": "b7dd2d90037ef1749e365a810180887e6ab5c33f",
                 "shasum": ""
             },
             "require": {
@@ -3022,9 +3022,9 @@
             "description": "The OpenDialog Core package",
             "support": {
                 "issues": "https://github.com/opendialogai/core/issues",
-                "source": "https://github.com/opendialogai/core/tree/feature/OPNDLG-832--default-trigger-conversation"
+                "source": "https://github.com/opendialogai/core/tree/fix/OPNDLG-846_button_message_value_validation"
             },
-            "time": "2021-06-16T16:41:28+00:00"
+            "time": "2021-06-21T13:53:33+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5ceded86dad9a5591acad681fc3ec263",
+    "content-hash": "6ca1747337a65d7aa514fe6692f0127c",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2937,16 +2937,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "dev-fix/OPNDLG-846_button_message_value_validation",
+            "version": "1.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "b7dd2d90037ef1749e365a810180887e6ab5c33f"
+                "reference": "59af8a9d4cf09c29bdca3999134d66f0d5dfe60c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/b7dd2d90037ef1749e365a810180887e6ab5c33f",
-                "reference": "b7dd2d90037ef1749e365a810180887e6ab5c33f",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/59af8a9d4cf09c29bdca3999134d66f0d5dfe60c",
+                "reference": "59af8a9d4cf09c29bdca3999134d66f0d5dfe60c",
                 "shasum": ""
             },
             "require": {
@@ -2973,6 +2973,7 @@
                 "phpunit/phpunit": "^9.0",
                 "squizlabs/php_codesniffer": "^3.4"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -3022,9 +3023,9 @@
             "description": "The OpenDialog Core package",
             "support": {
                 "issues": "https://github.com/opendialogai/core/issues",
-                "source": "https://github.com/opendialogai/core/tree/fix/OPNDLG-846_button_message_value_validation"
+                "source": "https://github.com/opendialogai/core/tree/1.x"
             },
-            "time": "2021-06-21T13:53:33+00:00"
+            "time": "2021-06-21T11:06:06+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",


### PR DESCRIPTION
This PR is dependent on https://github.com/opendialogai/core/pull/519 and updates the default conversations to:

 - Previously existing no-match conversation
 - New trigger conversation, a request-only conversation that transitions you to the welcome conversation
 - Updated welcome conversation, now a bot-led turn (that also includes a response user intent, so that the user doesn't no-match if they hit restart or send another trigger)