### PR TITLE
Log in page 419 error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "doctrine/dbal": "^2.9",
         "fideloper/proxy": "^4.2",
         "fruitcake/laravel-cors": "^2.0",
+        "genealabs/laravel-caffeine": "^8.0",
         "laravel/fortify": "^1.7",
         "laravel/framework": "^8.0",
         "laravel/legacy-factories": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4fe880ffb6078d9d214ac4555b66ed27",
+    "content-hash": "df4f584c2b9ca3eed76cb47230386eed",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/config/genealabs-laravel-caffeine.php
+++ b/config/genealabs-laravel-caffeine.php
@@ -1,0 +1,76 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Drip Interval
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the interval with which Caffeine for Laravel
+    | keeps the session alive. By default this is 5 minutes (expressed
+    | in milliseconds). This needs to be shorter than your session
+    | lifetime value configured set in "config/session.php".
+    |
+    | Default: 300000 (int)
+    |
+    */
+    'drip-interval' => ((int) env('SESSION_LIFETIME') * 60 * 1000) / 2,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Domain
+    |--------------------------------------------------------------------------
+    |
+    | You may optionally configure a separate domain that you are running
+    | Caffeine for Laravel on. This may be of interest if you have a
+    | monitoring service that queries other apps. Setting this to
+    | null will use the domain of the current application.
+    |
+    | Default: null (null|string)
+    |
+    */
+    'domain' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Drip Endpoint URL
+    |--------------------------------------------------------------------------
+    |
+    | Sometimes you may wish to white-label your app and not expose the AJAX
+    | request URLs as belonging to this package. To achieve that you can
+    | rename the URL used for dripping caffeine into your application.
+    |
+    | Default: 'genealabs/laravel-caffeine/drip' (string)
+    |
+    */
+    'route' => 'genealabs/laravel-caffeine/drip', // Customizable end-point URL
+
+    /*
+    |--------------------------------------------------------------------------
+    | Checking for Lapsed Drips
+    |--------------------------------------------------------------------------
+    |
+    | If the browser is put to sleep on (for example on mobil devices or
+    | laptops), it will still cause an error when trying to submit the
+    | form. To avoid this, we force-reload the form 2 minutes prior
+    | to session time-out or later. Setting this setting to 0
+    | will disable this check if you don't want to use it.
+    |
+    | Default: 2000 (int)
+    |
+    */
+    'outdated-drip-check-interval' => 2000,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Use Route Middleware
+    |--------------------------------------------------------------------------
+    |
+    | Drips are enabled via route middleware instead of global middleware.
+    |
+    | Default: false (bool)
+    |
+    */
+    'use-route-middleware' => false,
+
+];

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -23,8 +23,6 @@
                     @endif
 
                     <form method="POST" action="{{ route('login') }}">
-                        @csrf
-
                         <div class="form-group">
                             <label for="email">{{ __('E-Mail') }}</label>
                             <input id="email" type="email" class="form-control" name="email" value="{{ old('email') }}" required autofocus>
@@ -52,6 +50,8 @@
                         <button type="submit" class="btn btn-primary">
                             {{ __('Sign in') }}
                         </button>
+
+                        {{ csrf_field() }}
                     </form>
                 </div>
 </div>

--- a/resources/views/layouts/auth.blade.php
+++ b/resources/views/layouts/auth.blade.php
@@ -4,9 +4,6 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <!-- CSRF Token -->
-    <meta name="csrf-token" content="{{ csrf_token() }}">
-
     <title>{{ config('app.name', 'Laravel') }}</title>
 
     <!-- Scripts -->


### PR DESCRIPTION
This PR tries to address the issue fo 419 errors on the log in page if it has been left inactive for longer than the session time (120 mins by default)

Laravel-caffeine had already been added as a dependency on webchat package - this PR brings it into the main app and sets up the config so that:

- A drip request is sent when half of the session time expires
- hard refreshes the page if there is 2 minutes left on the session (this is to deal with mobiles and laptops going into sleep mode)

I tested this locally by setting the session time out to 1 minute without the caffeine set up - hits the 419 if logging in 1 min after session timeout. With the drip, can log in again at any point without refreshing