### PR TITLE
Removing starting behaviour from welcome conversation

### DIFF
--- a/app/Http/Controllers/API/ScenariosController.php
+++ b/app/Http/Controllers/API/ScenariosController.php
@@ -149,7 +149,8 @@ class ScenariosController extends Controller
             $welcomeOutgoingIntentId,
             "Hi! This is the default welcome message for the $scenarioName Scenario.",
             true,
-            $welcomeBotMessage->getMarkUp()
+            $welcomeBotMessage->getMarkUp(),
+            false
         );
 
         $triggerName = 'Trigger';
@@ -230,6 +231,8 @@ class ScenariosController extends Controller
      * @param string $outgoingIntentId
      * @param string $outgoingSampleUtterance
      * @param bool $botLed = false
+     * @param string|null $botMessage
+     * @param bool $isStarting
      * @return Conversation
      */
     private function createAtomicCallbackConversation(
@@ -240,11 +243,12 @@ class ScenariosController extends Controller
         string $outgoingIntentId,
         string $outgoingSampleUtterance,
         bool $botLed = false,
-        string $botMessage = null
+        string $botMessage = null,
+        bool $isStarting = true
     ): Conversation {
         $nameAsId = $this->convertNameToId($name);
 
-        $turn = $this->createConversationToTurn($scenario, $name, $nameAsId);
+        $turn = $this->createConversationToTurn($scenario, $name, $nameAsId, $isStarting);
 
         $incomingIntent = new Intent($turn, Intent::USER);
         $incomingIntent->setIsRequestIntent(!$botLed);
@@ -347,17 +351,22 @@ class ScenariosController extends Controller
     /**
      * @param Scenario $scenario
      * @param string $name
-     * @param $nameAsId
+     * @param string $nameAsId
+     * @param bool $isStarting
      * @return Turn
      */
-    private function createConversationToTurn(Scenario $scenario, string $name, $nameAsId): Turn
+    private function createConversationToTurn(Scenario $scenario, string $name, string $nameAsId, bool $isStarting = true): Turn
     {
         $conversation = new Conversation($scenario);
         $conversation->setName("$name Conversation");
         $conversation->setOdId(sprintf('%s_conversation', $nameAsId));
         $conversation->setDescription('Automatically generated');
         $conversation->setInterpreter('');
-        $conversation->setBehaviors(new BehaviorsCollection([new Behavior(Behavior::STARTING_BEHAVIOR)]));
+
+        if ($isStarting) {
+            $conversation->setBehaviors(new BehaviorsCollection([new Behavior(Behavior::STARTING_BEHAVIOR)]));
+        }
+
         $conversation->setCreatedAt(Carbon::now());
         $conversation->setUpdatedAt(Carbon::now());
 


### PR DESCRIPTION
This PR removes the starting behaviour from the welcome conversation, this is worth doing for two reasons:

1. It ensures that the conversation simulator does not incorrectly list the welcome conversation's request intent in the initial listing of possible intents (we should only get there via transition from the trigger conversation).
2. It ensures that if a designer creates a completing incoming intent that the outgoing welcome intent doesn't get incorrectly matched.

The starting behaviours have been preserved on the welcome scene & turn so that the welcome conversation & scene can be transitioned to - which allows designers to more easily make further use of the conversation, eg. they may add further turns and update the trigger conversation's transition to be a scene transition instead.