### PR TITLE
Ensuring duplicated outgoing intents get unique OD ID's

### DIFF
--- a/app/Http/Controllers/API/IntentsController.php
+++ b/app/Http/Controllers/API/IntentsController.php
@@ -74,6 +74,14 @@ class IntentsController extends Controller
     {
         $isRequest = $intent->isRequestIntent();
         $intent = IntentDataClient::getFullIntentGraph($intent->getUid());
+
+        if ($intent->getSpeaker() === Intent::APP) {
+            $turn = ConversationDataClient::getTurnByUid($intent->getTurn()->getUid());
+
+            /** @var Intent $intent */
+            $intent = $request->setUniqueOdId($intent, $turn, true);
+        }
+
         $intent->removeUid();
 
         $duplicate = IntentDataClient::addFullIntentGraph($intent, $isRequest);

--- a/app/Rules/OdId.php
+++ b/app/Rules/OdId.php
@@ -7,9 +7,11 @@ use Illuminate\Contracts\Validation\Rule;
 use OpenDialogAi\Core\Conversation\Conversation;
 use OpenDialogAi\Core\Conversation\ConversationObject;
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
+use OpenDialogAi\Core\Conversation\Intent;
 use OpenDialogAi\Core\Conversation\ODObjectCollection;
 use OpenDialogAi\Core\Conversation\Scenario;
 use OpenDialogAi\Core\Conversation\Scene;
+use OpenDialogAi\Core\Conversation\Turn;
 
 class OdId implements Rule
 {
@@ -77,6 +79,16 @@ class OdId implements Rule
                 case Scene::class:
                     /** @var Scene $parent */
                     $children = $parent->getTurns();
+                    break;
+
+                case Turn::class:
+                    /** @var Turn $parent */
+                    $children = $parent->getRequestIntents()
+                        ->merge($parent->getResponseIntents())
+                        ->filter(function (Intent $intent) {
+                            // Incoming intents shouldn't necessarily have unique OD ID's
+                            return $intent->getSpeaker() === Intent::APP;
+                        });
                     break;
             }
         }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "laravel/tinker": "^2.0",
         "laravel/ui": "^3.0",
         "maennchen/zipstream-php": "^2.0",
-        "opendialogai/core": "dev-fix/intent-duplication-suffix",
+        "opendialogai/core": "1.x-dev",
         "opendialogai/dgraph-docker": "21.03.0.2",
         "opendialogai/webchat": "1.x-dev",
         "phalcongelist/php-diff": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "laravel/tinker": "^2.0",
         "laravel/ui": "^3.0",
         "maennchen/zipstream-php": "^2.0",
-        "opendialogai/core": "1.x-dev",
+        "opendialogai/core": "dev-fix/intent-duplication-suffix",
         "opendialogai/dgraph-docker": "21.03.0.2",
         "opendialogai/webchat": "1.x-dev",
         "phalcongelist/php-diff": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4c21730714c7aef32a5896865fd049c3",
+    "content-hash": "df4f584c2b9ca3eed76cb47230386eed",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2916,16 +2916,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "dev-fix/intent-duplication-suffix",
+            "version": "1.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "661768111a527ac876520c76b07d04ada5a0022b"
+                "reference": "c4b88d7c3cebffc33693f817e89d0df22b2edf05"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/661768111a527ac876520c76b07d04ada5a0022b",
-                "reference": "661768111a527ac876520c76b07d04ada5a0022b",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/c4b88d7c3cebffc33693f817e89d0df22b2edf05",
+                "reference": "c4b88d7c3cebffc33693f817e89d0df22b2edf05",
                 "shasum": ""
             },
             "require": {
@@ -2952,6 +2952,7 @@
                 "phpunit/phpunit": "^9.0",
                 "squizlabs/php_codesniffer": "^3.4"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -3001,9 +3002,9 @@
             "description": "The OpenDialog Core package",
             "support": {
                 "issues": "https://github.com/opendialogai/core/issues",
-                "source": "https://github.com/opendialogai/core/tree/fix/intent-duplication-suffix"
+                "source": "https://github.com/opendialogai/core/tree/1.x"
             },
-            "time": "2021-07-06T14:36:26+00:00"
+            "time": "2021-07-07T09:59:22+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "df4f584c2b9ca3eed76cb47230386eed",
+    "content-hash": "4c21730714c7aef32a5896865fd049c3",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2916,16 +2916,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "1.x-dev",
+            "version": "dev-fix/intent-duplication-suffix",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "631c1c57cb3377be52a00f1262f6d496e611d556"
+                "reference": "661768111a527ac876520c76b07d04ada5a0022b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/631c1c57cb3377be52a00f1262f6d496e611d556",
-                "reference": "631c1c57cb3377be52a00f1262f6d496e611d556",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/661768111a527ac876520c76b07d04ada5a0022b",
+                "reference": "661768111a527ac876520c76b07d04ada5a0022b",
                 "shasum": ""
             },
             "require": {
@@ -2952,7 +2952,6 @@
                 "phpunit/phpunit": "^9.0",
                 "squizlabs/php_codesniffer": "^3.4"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -3002,9 +3001,9 @@
             "description": "The OpenDialog Core package",
             "support": {
                 "issues": "https://github.com/opendialogai/core/issues",
-                "source": "https://github.com/opendialogai/core/tree/1.x"
+                "source": "https://github.com/opendialogai/core/tree/fix/intent-duplication-suffix"
             },
-            "time": "2021-07-02T11:14:30+00:00"
+            "time": "2021-07-06T14:36:26+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "@coreui/coreui": "^2.1.12",
         "@coreui/icons": "^0.3.0",
         "@coreui/vue": "^2.1.2",
-        "@opendialogai/opendialog-design-system-pkg": "^0.2.57",
+        "@opendialogai/opendialog-design-system-pkg": "^0.2.58",
         "babel-runtime": "^6.26.0",
         "bootstrap-vue": "^2.21.2",
         "core-js": "^3.1.4",

--- a/tests/Feature/ScenariosTest.php
+++ b/tests/Feature/ScenariosTest.php
@@ -537,7 +537,7 @@ class ScenariosTest extends TestCase
         $requestIntent->setIsRequestIntent(true);
         $requestIntent->setName("Example Request Intent");
         $requestIntent->setUid('0x0005');
-        $requestIntent->setOdId("example_request_intent");
+        $requestIntent->setOdId("intent.app.exampleRequestIntent");
         $requestIntent->setCreatedAt(Carbon::now());
         $requestIntent->setUpdatedAt(Carbon::now());
         $requestIntent->setTurn($turns[0]);
@@ -548,7 +548,7 @@ class ScenariosTest extends TestCase
         $responseIntent->setIsRequestIntent(false);
         $responseIntent->setName("Example Response Intent");
         $responseIntent->setUid('0x0006');
-        $responseIntent->setOdId("example_response_intent");
+        $responseIntent->setOdId("intent.app.exampleResponseIntent");
         $responseIntent->setCreatedAt(Carbon::now());
         $responseIntent->setUpdatedAt(Carbon::now());
         $responseIntent->setTurn($turns[0]);
@@ -594,7 +594,7 @@ class ScenariosTest extends TestCase
         $requestIntent->setIsRequestIntent(true);
         $requestIntent->setName("Example Request Intent copy");
         $requestIntent->setUid('0x0005');
-        $requestIntent->setOdId("example_request_intent_copy");
+        $requestIntent->setOdId("intent.app.exampleRequestIntentCopy");
         $requestIntent->setCreatedAt(Carbon::now());
         $requestIntent->setUpdatedAt(Carbon::now());
         $requestIntent->setTurn($turns[0]);
@@ -604,7 +604,7 @@ class ScenariosTest extends TestCase
         $responseIntent->setIsRequestIntent(true);
         $responseIntent->setName("Example Response Intent copy");
         $responseIntent->setUid('0x0006');
-        $responseIntent->setOdId("example_response_intent_copy");
+        $responseIntent->setOdId("intent.app.exampleResponseIntentCopy");
         $responseIntent->setCreatedAt(Carbon::now());
         $responseIntent->setUpdatedAt(Carbon::now());
         $responseIntent->setTurn($turns[0]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -714,10 +714,10 @@
     consola "^2.15.0"
     node-fetch "^2.6.1"
 
-"@opendialogai/opendialog-design-system-pkg@^0.2.57":
-  version "0.2.57"
-  resolved "https://registry.yarnpkg.com/@opendialogai/opendialog-design-system-pkg/-/opendialog-design-system-pkg-0.2.57.tgz#8abdcea5ee8b0092c6267ea3e608159af81fc83f"
-  integrity sha512-cFp/6JbK4IO6DTXXbF6gD3Ez5UF/mFCcgqj+zU1pAyvXt/eaXfVk5TfLlofnXdrPdUgtOMUPw/3FgYVbCJHbcA==
+"@opendialogai/opendialog-design-system-pkg@^0.2.58":
+  version "0.2.58"
+  resolved "https://registry.yarnpkg.com/@opendialogai/opendialog-design-system-pkg/-/opendialog-design-system-pkg-0.2.58.tgz#37ea07001ad82314e6342516f90f17d3a5b52efe"
+  integrity sha512-yHkw1Ofi2nLk5eK06BF/yoXNqb+ELAydYcGkOBeW0mEraPswaCpGB8Odgm8cY0CSgyWXNd1oz+YvZePtROOD3w==
   dependencies:
     "@coreui/coreui" "^2.1.12"
     "@coreui/coreui-plugin-chartjs-custom-tooltips" "^1.3.1"


### PR DESCRIPTION
This PR is dependent on https://github.com/opendialogai/core/pull/535 and ensures that duplicated outgoing intents get unique OD ID's. Incoming intents still **do not** get unique OD ID's as they are important for interpretation.