### PR TITLE
Webchat settings command update

### DIFF
--- a/app/Console/Commands/SetWebchatSettings.php
+++ b/app/Console/Commands/SetWebchatSettings.php
@@ -13,7 +13,7 @@ class SetWebchatSettings extends Command
      *
      * @var string
      */
-    protected $signature = 'webchat:setup {settings?*} {--non-interactive}';
+    protected $signature = 'webchat:setup {settings?*} {--url=} {--non-interactive}';
 
     /**
      * The console command description.
@@ -48,7 +48,8 @@ class SetWebchatSettings extends Command
         Artisan::call('webchat:settings');
         $this->info('...done');
 
-        $odUrl = env('APP_URL');
+        $odUrl = $this->option('url') ? $this->option('url') : env('APP_URL');
+
         $commentsUrl = 'http://example.com';
         $token = 'ApiTokenValue';
 


### PR DESCRIPTION
This PR updates the webchat set up command so that it accepts the URL as an input option. If not present, reverts to using the APP_URL env. This allows more flexibility for setting up webchat for non-central domains