### PR TITLE
Fixing import export

### DIFF
--- a/app/ImportExportHelpers/ScenarioImportExportHelper.php
+++ b/app/ImportExportHelpers/ScenarioImportExportHelper.php
@@ -133,6 +133,7 @@ class ScenarioImportExportHelper extends BaseImportExportHelper
         }
 
         $persistedScenario = ScenarioDataClient::addFullScenarioGraph($importingScenario);
+        $persistedScenario = ScenarioDataClient::getFullScenarioGraph($persistedScenario->getUid());
 
         if (!$hasPathsToSubstitute) {
             return $persistedScenario;

--- a/tests/Feature/ImportExportScenariosTest.php
+++ b/tests/Feature/ImportExportScenariosTest.php
@@ -502,7 +502,7 @@ class ImportExportScenariosTest extends TestCase
 
         // After updates are made we get the full scenario with the updates included now
         ScenarioDataClient::shouldReceive('getFullScenarioGraph')
-            ->once()
+            ->times(3)
             ->andReturn($this->getMatchingExampleScenario());
 
         $this->artisan('scenarios:import')
@@ -560,7 +560,7 @@ class ImportExportScenariosTest extends TestCase
 
         // After updates are made we get the full scenario with the updates included now
         ScenarioDataClient::shouldReceive('getFullScenarioGraph')
-            ->once()
+            ->times(3)
             ->andReturn($this->getMatchingExampleScenario());
 
         $this->artisan('scenarios:import')
@@ -584,9 +584,19 @@ class ImportExportScenariosTest extends TestCase
 
         // Run the Import (Storage mocked)
         $storedMinimalScenario = $this->getMatchingMinimalScenario();
-        ConversationDataClient::shouldReceive('getAllScenarios')->twice()
+
+        ConversationDataClient::shouldReceive('getAllScenarios')
+            ->twice()
             ->andReturn(new ScenarioCollection([$storedExistingExampleScenario]));
-        ScenarioDataClient::shouldReceive('addFullScenarioGraph')->once()->andReturn($storedMinimalScenario);
+
+        ScenarioDataClient::shouldReceive('addFullScenarioGraph')
+            ->once()
+            ->andReturn($storedMinimalScenario);
+
+        ScenarioDataClient::shouldReceive('getFullScenarioGraph')
+            ->once()
+            ->andReturn($storedMinimalScenario);
+
         $this->artisan('scenarios:import')
             ->expectsOutput(sprintf(
                 "An existing Scenario with odId %s already exists!. Skipping %s!",
@@ -644,7 +654,7 @@ class ImportExportScenariosTest extends TestCase
 
         // After updates are made we get the full scenario with the updates included now
         ScenarioDataClient::shouldReceive('getFullScenarioGraph')
-            ->once()
+            ->times(3)
             ->andReturn($this->getMatchingExampleScenario());
 
         $this->artisan('scenarios:import');


### PR DESCRIPTION
This PR fixes a bug in which the scenario import command failed. This was introduced by changes to the data client which fully separated use of `getFull...` and `addFull...` methods - previously the add method would also call the get method, however this was changed due the nature of some uses resulted in many redundant graph queries via the get method.