### PR TITLE
Truncate webchat settings table for tests

### DIFF
--- a/tests/Feature/WebchatSettingsTest.php
+++ b/tests/Feature/WebchatSettingsTest.php
@@ -17,6 +17,9 @@ class WebchatSettingsTest extends TestCase
         parent::setUp();
 
         $this->user = factory(User::class)->create();
+
+        // Ensure we start with am empty webchat settings table
+        WebchatSetting::truncate();
     }
 
     public function testWebchatSettingsViewEndpoint()

--- a/tests/Unit/SetWebchatSettingsTest.php
+++ b/tests/Unit/SetWebchatSettingsTest.php
@@ -8,6 +8,14 @@ use OpenDialogAi\Webchat\WebchatSetting;
 
 class SetWebchatSettingsTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Ensure we start with am empty webchat settings table
+        WebchatSetting::truncate();
+    }
+
     public function testCommand()
     {
         // Confirm that settings are not set before the command is run


### PR DESCRIPTION
This PR ensures that the webchat settings table is truncated before running any tests against it.

For base OpenDialog this is always the case, but this is a belt and braces approach