### PR TITLE
OD ID validation attribute mapping

### DIFF
--- a/app/Http/Requests/ConversationObjectRequestTrait.php
+++ b/app/Http/Requests/ConversationObjectRequestTrait.php
@@ -14,4 +14,11 @@ trait ConversationObjectRequestTrait
             'od_id' => ['bail', 'string', 'filled', 'not_regex:/[\$\:\/]/', new OdId($parent, $currentUid)],
         ];
     }
+
+    public function attributes()
+    {
+        return [
+            'od_id' => 'name'
+        ];
+    }
 }


### PR DESCRIPTION
This PR updates the attribute name used in Laravel's validation messaging for `od_id`'s. Previously if validation for `od_id` failed, the validation error message would read: "The od id field must...", after this change it reads "The name field must..." which is more understandable in the context of the UI, in which we don't actually allow user input for OD ID (it is generated from the name).