### PR TITLE
Callback interpreter testing fixes

### DIFF
--- a/app/Http/Controllers/API/ComponentConfigurationController.php
+++ b/app/Http/Controllers/API/ComponentConfigurationController.php
@@ -191,7 +191,7 @@ class ComponentConfigurationController extends Controller
 
             $utterance = new UtteranceAttribute('configuration_test');
             $utterance->setText($text);
-            $utterance->setCallbackId("test");
+            $utterance->setCallbackId($text);
 
             $configuration = $interpreterClass::createConfiguration('test', $request->get('configuration'));
             $interpreter = new $interpreterClass($configuration);

--- a/app/Http/Requests/ComponentConfigurationTestRequest.php
+++ b/app/Http/Requests/ComponentConfigurationTestRequest.php
@@ -16,8 +16,8 @@ class ComponentConfigurationTestRequest extends ComponentConfigurationRequest
         $rules = [];
         $rules['component_id'] = $originalRules['component_id'];
         $rules['configuration'] = $originalRules['configuration'];
-        $rules['configuration.app_url'] = $originalRules['configuration.app_url'];
-        $rules['configuration.webhook_url'] = $originalRules['configuration.webhook_url'];
+        $rules['configuration.app_url'] = $originalRules['configuration.app_url'] ?? [];
+        $rules['configuration.webhook_url'] = $originalRules['configuration.webhook_url'] ?? [];
 
         return $rules;
     }


### PR DESCRIPTION
This PR ensures that the provided utterance value is used as a callback value when testing an interpreter. This means that now, when testing the callback interpreter, we can validate that our mappings work (see below). This PR also fixes a small bug in which when running the application with `APP_ENV=local`, the configuration test request object had undefined indexes for some inherited rules.

![Screenshot 2021-07-14 at 15 55 54](https://user-images.githubusercontent.com/6834105/125644178-a9830fd3-0086-4875-96da-686178c1c2c7.png)
