### PR TITLE
Feature/transition deletion validation

### DIFF
--- a/app/Http/Controllers/API/ConversationsController.php
+++ b/app/Http/Controllers/API/ConversationsController.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Facades\Serializer;
 use App\Http\Requests\ConversationObjectDuplicationRequest;
 use App\Http\Requests\ConversationRequest;
+use App\Http\Requests\DeleteConversationRequest;
 use App\Http\Requests\SceneRequest;
 use App\Http\Resources\ConversationResource;
 use App\Http\Resources\SceneResource;
@@ -18,6 +19,7 @@ use Illuminate\Http\Response;
 use OpenDialogAi\Core\Conversation\Conversation;
 use OpenDialogAi\Core\Conversation\DataClients\Serializers\Normalizers\ImportExport\ScenarioNormalizer;
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
+use OpenDialogAi\Core\Conversation\Facades\IntentDataClient;
 use OpenDialogAi\Core\Conversation\Scene;
 
 class ConversationsController extends Controller
@@ -102,10 +104,11 @@ class ConversationsController extends Controller
     /**
      * Destroy the specified scenario.
      *
+     * @param DeleteConversationRequest $request
      * @param Conversation $conversation
      * @return Response $response
      */
-    public function destroy(Conversation $conversation): Response
+    public function destroy(DeleteConversationRequest $request, Conversation $conversation): Response
     {
         if (ConversationDataClient::deleteConversationByUid($conversation->getUid())) {
             return response()->noContent(200);

--- a/app/Http/Controllers/API/ScenesController.php
+++ b/app/Http/Controllers/API/ScenesController.php
@@ -7,6 +7,7 @@ use App\Console\Facades\ImportExportSerializer;
 use App\Http\Controllers\Controller;
 use App\Http\Facades\Serializer;
 use App\Http\Requests\ConversationObjectDuplicationRequest;
+use App\Http\Requests\DeleteSceneRequest;
 use App\Http\Requests\SceneRequest;
 use App\Http\Requests\TurnRequest;
 use App\Http\Resources\SceneResource;
@@ -90,10 +91,11 @@ class ScenesController extends Controller
     /**
      * Destroy the specified scenario.
      *
+     * @param DeleteSceneRequest $request
      * @param Scene $scene
      * @return Response $response
      */
-    public function destroy(Scene $scene): Response
+    public function destroy(DeleteSceneRequest $request, Scene $scene): Response
     {
         if (ConversationDataClient::deleteSceneByUid($scene->getUid())) {
             return response()->noContent(200);

--- a/app/Http/Controllers/API/TurnsController.php
+++ b/app/Http/Controllers/API/TurnsController.php
@@ -7,6 +7,7 @@ use App\Console\Facades\ImportExportSerializer;
 use App\Http\Controllers\Controller;
 use App\Http\Facades\Serializer;
 use App\Http\Requests\ConversationObjectDuplicationRequest;
+use App\Http\Requests\DeleteTurnRequest;
 use App\Http\Requests\TurnIntentRequest;
 use App\Http\Requests\TurnRequest;
 use App\Http\Resources\TurnIntentResource;
@@ -110,11 +111,11 @@ class TurnsController extends Controller
     }
 
     /**
-     *
+     * @param DeleteTurnRequest $request
      * @param Turn $Turn
      * @return Response $response
      */
-    public function destroy(Turn $Turn): Response
+    public function destroy(DeleteTurnRequest $request, Turn $Turn): Response
     {
         if (ConversationDataClient::deleteTurnByUid($Turn->getUid())) {
             return response()->noContent(200);

--- a/app/Http/Requests/DeleteConversationRequest.php
+++ b/app/Http/Requests/DeleteConversationRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Rules\ConversationInTransition;
+use Illuminate\Foundation\Http\FormRequest;
+
+class DeleteConversationRequest extends FormRequest
+{
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function rules()
+    {
+        return [
+            'conversation_id' => [new ConversationInTransition()]
+        ];
+    }
+
+    /**
+     * Fetches the conversation ID from the route param
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge(['conversation_id' => $this->route('conversation')->getUid()]);
+    }
+}

--- a/app/Http/Requests/DeleteConversationRequest.php
+++ b/app/Http/Requests/DeleteConversationRequest.php
@@ -15,7 +15,7 @@ class DeleteConversationRequest extends FormRequest
     public function rules()
     {
         return [
-            'conversation_id' => [new ConversationInTransition()]
+            'conversation' => [new ConversationInTransition()]
         ];
     }
 
@@ -24,6 +24,6 @@ class DeleteConversationRequest extends FormRequest
      */
     protected function prepareForValidation()
     {
-        $this->merge(['conversation_id' => $this->route('conversation')->getUid()]);
+        $this->merge(['conversation' => $this->route('conversation')]);
     }
 }

--- a/app/Http/Requests/DeleteConversationRequest.php
+++ b/app/Http/Requests/DeleteConversationRequest.php
@@ -15,7 +15,7 @@ class DeleteConversationRequest extends FormRequest
     public function rules()
     {
         return [
-            'conversation' => [new ConversationInTransition()]
+            'transition_intents' => [new ConversationInTransition()]
         ];
     }
 
@@ -24,6 +24,6 @@ class DeleteConversationRequest extends FormRequest
      */
     protected function prepareForValidation()
     {
-        $this->merge(['conversation' => $this->route('conversation')]);
+        $this->merge(['transition_intents' => $this->route('conversation')]);
     }
 }

--- a/app/Http/Requests/DeleteSceneRequest.php
+++ b/app/Http/Requests/DeleteSceneRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Rules\SceneInTransition;
+use Illuminate\Foundation\Http\FormRequest;
+
+class DeleteSceneRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'scene_id' => [new SceneInTransition()]
+        ];
+    }
+
+    /**
+     * Fetches the conversation ID from the route param
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge(['scene_id' => $this->route('scene')->getUid()]);
+    }
+}

--- a/app/Http/Requests/DeleteSceneRequest.php
+++ b/app/Http/Requests/DeleteSceneRequest.php
@@ -25,7 +25,7 @@ class DeleteSceneRequest extends FormRequest
     public function rules()
     {
         return [
-            'scene_id' => [new SceneInTransition()]
+            'scene' => [new SceneInTransition()]
         ];
     }
 
@@ -34,6 +34,6 @@ class DeleteSceneRequest extends FormRequest
      */
     protected function prepareForValidation()
     {
-        $this->merge(['scene_id' => $this->route('scene')->getUid()]);
+        $this->merge(['scene' => $this->route('scene')]);
     }
 }

--- a/app/Http/Requests/DeleteSceneRequest.php
+++ b/app/Http/Requests/DeleteSceneRequest.php
@@ -25,7 +25,7 @@ class DeleteSceneRequest extends FormRequest
     public function rules()
     {
         return [
-            'scene' => [new SceneInTransition()]
+            'transition_intents' => [new SceneInTransition()]
         ];
     }
 
@@ -34,6 +34,6 @@ class DeleteSceneRequest extends FormRequest
      */
     protected function prepareForValidation()
     {
-        $this->merge(['scene' => $this->route('scene')]);
+        $this->merge(['transition_intents' => $this->route('scene')]);
     }
 }

--- a/app/Http/Requests/DeleteTurnRequest.php
+++ b/app/Http/Requests/DeleteTurnRequest.php
@@ -25,7 +25,7 @@ class DeleteTurnRequest extends FormRequest
     public function rules()
     {
         return [
-            'turn_id' => [new TurnInTransition()]
+            'turn' => [new TurnInTransition()]
         ];
     }
 
@@ -34,6 +34,6 @@ class DeleteTurnRequest extends FormRequest
      */
     protected function prepareForValidation()
     {
-        $this->merge(['turn_id' => $this->route('turn')->getUid()]);
+        $this->merge(['turn' => $this->route('turn')]);
     }
 }

--- a/app/Http/Requests/DeleteTurnRequest.php
+++ b/app/Http/Requests/DeleteTurnRequest.php
@@ -25,7 +25,7 @@ class DeleteTurnRequest extends FormRequest
     public function rules()
     {
         return [
-            'turn' => [new TurnInTransition()]
+            'transition_intents' => [new TurnInTransition()]
         ];
     }
 
@@ -34,6 +34,6 @@ class DeleteTurnRequest extends FormRequest
      */
     protected function prepareForValidation()
     {
-        $this->merge(['turn' => $this->route('turn')]);
+        $this->merge(['transition_intents' => $this->route('turn')]);
     }
 }

--- a/app/Http/Requests/DeleteTurnRequest.php
+++ b/app/Http/Requests/DeleteTurnRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Rules\TurnInTransition;
+use Illuminate\Foundation\Http\FormRequest;
+
+class DeleteTurnRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'turn_id' => [new TurnInTransition()]
+        ];
+    }
+
+    /**
+     * Fetches the conversation ID from the route param
+     */
+    protected function prepareForValidation()
+    {
+        $this->merge(['turn_id' => $this->route('turn')->getUid()]);
+    }
+}

--- a/app/Rules/BaseTransitionRule.php
+++ b/app/Rules/BaseTransitionRule.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use OpenDialogAi\Core\Conversation\Intent;
+use OpenDialogAi\Core\Conversation\IntentCollection;
+
+abstract class BaseTransitionRule implements Rule
+{
+    protected $linkedIntents;
+
+    public function message()
+    {
+        return $this->getErrorMessage($this->linkedIntents);
+    }
+
+    protected function getErrorMessage(IntentCollection $linkedIntents): array
+    {
+        $affectedIntents = [];
+
+        $linkedIntents->each(function (Intent $intent) use (&$affectedIntents) {
+            $affectedIntents[] = [$intent->getName() => $intent->getUid()];
+        });
+
+        return $affectedIntents;
+    }
+}

--- a/app/Rules/ConversationInTransition.php
+++ b/app/Rules/ConversationInTransition.php
@@ -3,7 +3,9 @@
 namespace App\Rules;
 
 use Illuminate\Contracts\Validation\Rule;
+use OpenDialogAi\Core\Conversation\Conversation;
 use OpenDialogAi\Core\Conversation\Facades\IntentDataClient;
+use OpenDialogAi\Core\Conversation\Intent;
 use OpenDialogAi\Core\Conversation\IntentCollection;
 
 class ConversationInTransition implements Rule
@@ -14,13 +16,18 @@ class ConversationInTransition implements Rule
      * Determine if the validation rule passes.
      *
      * @param  string  $attribute
-     * @param  mixed  $value
+     * @param  Conversation  $value
      * @return bool
      */
     public function passes($attribute, $value)
     {
-        $this->linkedIntents = IntentDataClient::getIntentWithConversationTransition($value);
-        return $this->linkedIntents->count() === 0;
+        $linkedIntents = IntentDataClient::getIntentWithConversationTransition($value->getUid());
+
+        $linkedIntents = $linkedIntents->filter(function (Intent $intent) use ($value) {
+            return $intent->getTurn()->getScene()->getConversation()->getUid() !== $value->getUid();
+        });
+
+        return $linkedIntents->count() === 0;
     }
 
     /**

--- a/app/Rules/ConversationInTransition.php
+++ b/app/Rules/ConversationInTransition.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use OpenDialogAi\Core\Conversation\Facades\IntentDataClient;
+use OpenDialogAi\Core\Conversation\IntentCollection;
+
+class ConversationInTransition implements Rule
+{
+    private IntentCollection $linkedIntents;
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        $this->linkedIntents = IntentDataClient::getIntentWithConversationTransition($value);
+        return $this->linkedIntents->count() === 0;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'The conversation is used in a transaction';
+    }
+}

--- a/app/Rules/ConversationInTransition.php
+++ b/app/Rules/ConversationInTransition.php
@@ -2,16 +2,12 @@
 
 namespace App\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
 use OpenDialogAi\Core\Conversation\Conversation;
 use OpenDialogAi\Core\Conversation\Facades\IntentDataClient;
 use OpenDialogAi\Core\Conversation\Intent;
-use OpenDialogAi\Core\Conversation\IntentCollection;
 
-class ConversationInTransition implements Rule
+class ConversationInTransition extends BaseTransitionRule
 {
-    private IntentCollection $linkedIntents;
-
     /**
      * Determine if the validation rule passes.
      *
@@ -27,16 +23,8 @@ class ConversationInTransition implements Rule
             return $intent->getTurn()->getScene()->getConversation()->getUid() !== $value->getUid();
         });
 
-        return $linkedIntents->count() === 0;
-    }
+        $this->linkedIntents = $linkedIntents;
 
-    /**
-     * Get the validation error message.
-     *
-     * @return string
-     */
-    public function message()
-    {
-        return 'The conversation is used in a transaction';
+        return $linkedIntents->count() === 0;
     }
 }

--- a/app/Rules/SceneInTransition.php
+++ b/app/Rules/SceneInTransition.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use OpenDialogAi\Core\Conversation\Facades\IntentDataClient;
+use OpenDialogAi\Core\Conversation\IntentCollection;
+
+class SceneInTransition implements Rule
+{
+    private IntentCollection $linkedIntents;
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        $this->linkedIntents = IntentDataClient::getIntentWithSceneTransition($value);
+        return $this->linkedIntents->count() === 0;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'The scene is used in a transition.';
+    }
+}

--- a/app/Rules/SceneInTransition.php
+++ b/app/Rules/SceneInTransition.php
@@ -2,16 +2,12 @@
 
 namespace App\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
 use OpenDialogAi\Core\Conversation\Facades\IntentDataClient;
 use OpenDialogAi\Core\Conversation\Intent;
-use OpenDialogAi\Core\Conversation\IntentCollection;
 use OpenDialogAi\Core\Conversation\Scene;
 
-class SceneInTransition implements Rule
+class SceneInTransition extends BaseTransitionRule
 {
-    private IntentCollection $linkedIntents;
-
     /**
      * Determine if the validation rule passes.
      *
@@ -27,16 +23,7 @@ class SceneInTransition implements Rule
             return $intent->getTurn()->getScene()->getUid() !== $value->getUid();
         });
 
+        $this->linkedIntents = $linkedIntents;
         return $linkedIntents->count() === 0;
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string
-     */
-    public function message()
-    {
-        return 'The scene is used in a transition.';
     }
 }

--- a/app/Rules/SceneInTransition.php
+++ b/app/Rules/SceneInTransition.php
@@ -4,7 +4,9 @@ namespace App\Rules;
 
 use Illuminate\Contracts\Validation\Rule;
 use OpenDialogAi\Core\Conversation\Facades\IntentDataClient;
+use OpenDialogAi\Core\Conversation\Intent;
 use OpenDialogAi\Core\Conversation\IntentCollection;
+use OpenDialogAi\Core\Conversation\Scene;
 
 class SceneInTransition implements Rule
 {
@@ -14,13 +16,18 @@ class SceneInTransition implements Rule
      * Determine if the validation rule passes.
      *
      * @param  string  $attribute
-     * @param  mixed  $value
+     * @param  Scene  $value
      * @return bool
      */
     public function passes($attribute, $value)
     {
-        $this->linkedIntents = IntentDataClient::getIntentWithSceneTransition($value);
-        return $this->linkedIntents->count() === 0;
+        $linkedIntents = IntentDataClient::getIntentWithSceneTransition($value->getUid());
+
+        $linkedIntents = $linkedIntents->filter(function (Intent $intent) use ($value) {
+            return $intent->getTurn()->getScene()->getUid() !== $value->getUid();
+        });
+
+        return $linkedIntents->count() === 0;
     }
 
     /**

--- a/app/Rules/TurnInTransition.php
+++ b/app/Rules/TurnInTransition.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use OpenDialogAi\Core\Conversation\Facades\IntentDataClient;
+use OpenDialogAi\Core\Conversation\IntentCollection;
+
+class TurnInTransition implements Rule
+{
+    private IntentCollection $linkedIntents;
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        $this->linkedIntents = IntentDataClient::getIntentWithTurnTransition($value);
+        return $this->linkedIntents->count() === 0;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'The turn is used in a transition.';
+    }
+}

--- a/app/Rules/TurnInTransition.php
+++ b/app/Rules/TurnInTransition.php
@@ -4,7 +4,9 @@ namespace App\Rules;
 
 use Illuminate\Contracts\Validation\Rule;
 use OpenDialogAi\Core\Conversation\Facades\IntentDataClient;
+use OpenDialogAi\Core\Conversation\Intent;
 use OpenDialogAi\Core\Conversation\IntentCollection;
+use OpenDialogAi\Core\Conversation\Turn;
 
 class TurnInTransition implements Rule
 {
@@ -14,13 +16,18 @@ class TurnInTransition implements Rule
      * Determine if the validation rule passes.
      *
      * @param  string  $attribute
-     * @param  mixed  $value
+     * @param  Turn  $value
      * @return bool
      */
     public function passes($attribute, $value)
     {
-        $this->linkedIntents = IntentDataClient::getIntentWithTurnTransition($value);
-        return $this->linkedIntents->count() === 0;
+        $linkedIntents = IntentDataClient::getIntentWithTurnTransition($value->getUid());
+
+        $linkedIntents = $linkedIntents->filter(function (Intent $intent) use ($value) {
+            return $intent->getTurn()->getUid() !== $value->getUid();
+        });
+
+        return $linkedIntents->count() === 0;
     }
 
     /**

--- a/app/Rules/TurnInTransition.php
+++ b/app/Rules/TurnInTransition.php
@@ -2,16 +2,12 @@
 
 namespace App\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
 use OpenDialogAi\Core\Conversation\Facades\IntentDataClient;
 use OpenDialogAi\Core\Conversation\Intent;
-use OpenDialogAi\Core\Conversation\IntentCollection;
 use OpenDialogAi\Core\Conversation\Turn;
 
-class TurnInTransition implements Rule
+class TurnInTransition extends BaseTransitionRule
 {
-    private IntentCollection $linkedIntents;
-
     /**
      * Determine if the validation rule passes.
      *
@@ -27,16 +23,7 @@ class TurnInTransition implements Rule
             return $intent->getTurn()->getUid() !== $value->getUid();
         });
 
+        $this->linkedIntents = $linkedIntents;
         return $linkedIntents->count() === 0;
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string
-     */
-    public function message()
-    {
-        return 'The turn is used in a transition.';
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "laravel/tinker": "^2.0",
         "laravel/ui": "^3.0",
         "maennchen/zipstream-php": "^2.0",
-        "opendialogai/core": "dev-feature/intent_transition_queries",
+        "opendialogai/core": "1.x-dev",
         "opendialogai/dgraph-docker": "21.03.0.2",
         "opendialogai/webchat": "1.x-dev",
         "phalcongelist/php-diff": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "laravel/tinker": "^2.0",
         "laravel/ui": "^3.0",
         "maennchen/zipstream-php": "^2.0",
-        "opendialogai/core": "1.x-dev",
+        "opendialogai/core": "dev-feature/intent_transition_queries",
         "opendialogai/dgraph-docker": "21.03.0.2",
         "opendialogai/webchat": "1.x-dev",
         "phalcongelist/php-diff": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aaeea8b307db34aaa4b804b9c76b087d",
+    "content-hash": "df4f584c2b9ca3eed76cb47230386eed",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2916,16 +2916,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "dev-feature/intent_transition_queries",
+            "version": "1.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "663ee03cab0344b9950e1a4491f5ba11fc8c0c2a"
+                "reference": "3f4631cacc50ab96b6be27fe7155f945a7a45953"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/663ee03cab0344b9950e1a4491f5ba11fc8c0c2a",
-                "reference": "663ee03cab0344b9950e1a4491f5ba11fc8c0c2a",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/3f4631cacc50ab96b6be27fe7155f945a7a45953",
+                "reference": "3f4631cacc50ab96b6be27fe7155f945a7a45953",
                 "shasum": ""
             },
             "require": {
@@ -2952,6 +2952,7 @@
                 "phpunit/phpunit": "^9.0",
                 "squizlabs/php_codesniffer": "^3.4"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -3001,9 +3002,9 @@
             "description": "The OpenDialog Core package",
             "support": {
                 "issues": "https://github.com/opendialogai/core/issues",
-                "source": "https://github.com/opendialogai/core/tree/feature/intent_transition_queries"
+                "source": "https://github.com/opendialogai/core/tree/1.x"
             },
-            "time": "2021-07-15T10:51:25+00:00"
+            "time": "2021-07-15T15:45:17+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/composer.lock
+++ b/composer.lock
@@ -2920,12 +2920,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "424feb878bd3e5a83800e9ccc2541b2f6d2c52a2"
+                "reference": "663ee03cab0344b9950e1a4491f5ba11fc8c0c2a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/424feb878bd3e5a83800e9ccc2541b2f6d2c52a2",
-                "reference": "424feb878bd3e5a83800e9ccc2541b2f6d2c52a2",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/663ee03cab0344b9950e1a4491f5ba11fc8c0c2a",
+                "reference": "663ee03cab0344b9950e1a4491f5ba11fc8c0c2a",
                 "shasum": ""
             },
             "require": {
@@ -3003,7 +3003,7 @@
                 "issues": "https://github.com/opendialogai/core/issues",
                 "source": "https://github.com/opendialogai/core/tree/feature/intent_transition_queries"
             },
-            "time": "2021-07-15T09:31:41+00:00"
+            "time": "2021-07-15T10:51:25+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "df4f584c2b9ca3eed76cb47230386eed",
+    "content-hash": "aaeea8b307db34aaa4b804b9c76b087d",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2916,16 +2916,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "1.x-dev",
+            "version": "dev-feature/intent_transition_queries",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "2ad52c96821f41f489fbb894a5167ea3118b769b"
+                "reference": "424feb878bd3e5a83800e9ccc2541b2f6d2c52a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/2ad52c96821f41f489fbb894a5167ea3118b769b",
-                "reference": "2ad52c96821f41f489fbb894a5167ea3118b769b",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/424feb878bd3e5a83800e9ccc2541b2f6d2c52a2",
+                "reference": "424feb878bd3e5a83800e9ccc2541b2f6d2c52a2",
                 "shasum": ""
             },
             "require": {
@@ -2952,7 +2952,6 @@
                 "phpunit/phpunit": "^9.0",
                 "squizlabs/php_codesniffer": "^3.4"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -3002,9 +3001,9 @@
             "description": "The OpenDialog Core package",
             "support": {
                 "issues": "https://github.com/opendialogai/core/issues",
-                "source": "https://github.com/opendialogai/core/tree/1.x"
+                "source": "https://github.com/opendialogai/core/tree/feature/intent_transition_queries"
             },
-            "time": "2021-07-13T14:22:36+00:00"
+            "time": "2021-07-15T09:31:41+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/tests/Feature/ConversationsTest.php
+++ b/tests/Feature/ConversationsTest.php
@@ -14,6 +14,8 @@ use OpenDialogAi\Core\Conversation\Facades\IntentDataClient;
 use OpenDialogAi\Core\Conversation\Intent;
 use OpenDialogAi\Core\Conversation\IntentCollection;
 use OpenDialogAi\Core\Conversation\Scenario;
+use OpenDialogAi\Core\Conversation\Scene;
+use OpenDialogAi\Core\Conversation\Turn;
 use Tests\TestCase;
 
 class ConversationsTest extends TestCase
@@ -295,6 +297,36 @@ class ConversationsTest extends TestCase
         $this->actingAs($this->user, 'api')
             ->json('DELETE', '/admin/api/conversation-builder/conversations/' . $fakeConversation->getUid())
             ->assertStatus(422);
+    }
+
+    /** If the intent with the transition is in the conversation being deleted, we should allow it through */
+    public function testDeleteConversationByUidInUseBySelf()
+    {
+        $fakeConversation = new Conversation();
+        $fakeConversation->setUid('0x0001');
+        $fakeConversation->setOdId('new_example_conversation');
+        $fakeConversation->setName('New Example conversation');
+        $fakeConversation->setDescription('An new example conversation');
+
+        ConversationDataClient::shouldReceive('getConversationByUid')
+            ->once()
+            ->with($fakeConversation->getUid(), false)
+            ->andReturn($fakeConversation);
+
+        ConversationDataClient::shouldReceive('deleteConversationByUid')
+            ->once()
+            ->with($fakeConversation->getUid())
+            ->andReturn(true);
+
+        $intent = new Intent(new Turn(new Scene($fakeConversation)));
+        IntentDataClient::shouldReceive('getIntentWithConversationTransition')
+            ->once()
+            ->with($fakeConversation->getUid())
+            ->andReturn(new IntentCollection([$intent]));
+
+        $this->actingAs($this->user, 'api')
+            ->json('DELETE', '/admin/api/conversation-builder/conversations/' . $fakeConversation->getUid())
+            ->assertStatus(200);
     }
 
     public function testDuplication()

--- a/tests/Feature/ConversationsTest.php
+++ b/tests/Feature/ConversationsTest.php
@@ -10,6 +10,9 @@ use OpenDialogAi\Core\Conversation\Conversation;
 use OpenDialogAi\Core\Conversation\ConversationCollection;
 use OpenDialogAi\Core\Conversation\Exceptions\ConversationObjectNotFoundException;
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
+use OpenDialogAi\Core\Conversation\Facades\IntentDataClient;
+use OpenDialogAi\Core\Conversation\Intent;
+use OpenDialogAi\Core\Conversation\IntentCollection;
 use OpenDialogAi\Core\Conversation\Scenario;
 use Tests\TestCase;
 
@@ -258,9 +261,40 @@ class ConversationsTest extends TestCase
             ->with($fakeConversation->getUid())
             ->andReturn(true);
 
+        IntentDataClient::shouldReceive('getIntentWithConversationTransition')
+            ->once()
+            ->with($fakeConversation->getUid())
+            ->andReturn(new IntentCollection());
+
         $this->actingAs($this->user, 'api')
             ->json('DELETE', '/admin/api/conversation-builder/conversations/' . $fakeConversation->getUid())
             ->assertStatus(200);
+    }
+
+    public function testDeleteConversationByUidInUse()
+    {
+        $fakeConversation = new Conversation();
+        $fakeConversation->setUid('0x0001');
+        $fakeConversation->setOdId('new_example_conversation');
+        $fakeConversation->setName('New Example conversation');
+        $fakeConversation->setDescription('An new example conversation');
+
+        ConversationDataClient::shouldReceive('getConversationByUid')
+            ->once()
+            ->with($fakeConversation->getUid(), false)
+            ->andReturn($fakeConversation);
+
+        ConversationDataClient::shouldReceive('deleteConversationByUid')
+            ->never();
+
+        IntentDataClient::shouldReceive('getIntentWithConversationTransition')
+            ->once()
+            ->with($fakeConversation->getUid())
+            ->andReturn(new IntentCollection(new Intent()));
+
+        $this->actingAs($this->user, 'api')
+            ->json('DELETE', '/admin/api/conversation-builder/conversations/' . $fakeConversation->getUid())
+            ->assertStatus(422);
     }
 
     public function testDuplication()
@@ -278,7 +312,9 @@ class ConversationsTest extends TestCase
         // Called in the controller, getting parent & sibling data
         ConversationDataClient::shouldReceive('getScenarioByUid')
             ->once()
-            ->andReturnUsing(function ($uid) use ($scenario) { return $scenario; });
+            ->andReturnUsing(function ($uid) use ($scenario) {
+                return $scenario;
+            });
 
         // Called in controller, once before persisting, again after, and finally after patching
         ConversationDataClient::shouldReceive('getFullConversationGraph')

--- a/tests/Feature/ConversationsTest.php
+++ b/tests/Feature/ConversationsTest.php
@@ -289,10 +289,12 @@ class ConversationsTest extends TestCase
         ConversationDataClient::shouldReceive('deleteConversationByUid')
             ->never();
 
+        $conversation = new Conversation();
+        $conversation->setUid('different');
         IntentDataClient::shouldReceive('getIntentWithConversationTransition')
             ->once()
             ->with($fakeConversation->getUid())
-            ->andReturn(new IntentCollection(new Intent()));
+            ->andReturn(new IntentCollection([new Intent(new Turn(new Scene($conversation)))]));
 
         $this->actingAs($this->user, 'api')
             ->json('DELETE', '/admin/api/conversation-builder/conversations/' . $fakeConversation->getUid())

--- a/tests/Feature/ScenesTest.php
+++ b/tests/Feature/ScenesTest.php
@@ -313,10 +313,13 @@ class ScenesTest extends TestCase
         ConversationDataClient::shouldReceive('deleteSceneByUid')
             ->never();
 
+        $scene = new Scene();
+        $scene->setUid('different');
+
         IntentDataClient::shouldReceive('getIntentWithSceneTransition')
             ->once()
             ->with($fakeScene->getUid())
-            ->andReturn(new IntentCollection(new Intent()));
+            ->andReturn(new IntentCollection([new Intent(new Turn($scene))]));
 
         $this->actingAs($this->user, 'api')
             ->json('DELETE', '/admin/api/conversation-builder/scenes/' . $fakeScene->getUid())

--- a/tests/Feature/TurnsTest.php
+++ b/tests/Feature/TurnsTest.php
@@ -325,10 +325,12 @@ class TurnsTest extends TestCase
         ConversationDataClient::shouldReceive('deleteTurnByUid')
             ->never();
 
+        $turn = new Turn();
+        $turn->setUid('different');
         IntentDataClient::shouldReceive('getIntentWithTurnTransition')
             ->once()
             ->with($fakeTurn->getUid())
-            ->andReturn(new IntentCollection(new Intent()));
+            ->andReturn(new IntentCollection([new Intent($turn)]));
 
         $this->actingAs($this->user, 'api')
             ->json('DELETE', '/admin/api/conversation-builder/turns/' . $fakeTurn->getUid())

--- a/tests/Feature/TurnsTest.php
+++ b/tests/Feature/TurnsTest.php
@@ -337,7 +337,7 @@ class TurnsTest extends TestCase
             ->assertStatus(422);
     }
 
-    public function testDeleteTurnByUidInUseInUse()
+    public function testDeleteTurnByUidInUseBySelf()
     {
         $fakeTurn = new Turn();
         $fakeTurn->setUid('0x0001');
@@ -351,16 +351,18 @@ class TurnsTest extends TestCase
             ->andReturn($fakeTurn);
 
         ConversationDataClient::shouldReceive('deleteTurnByUid')
-            ->never();
+            ->once()
+            ->with($fakeTurn->getUid())
+            ->andReturn(true);
 
         IntentDataClient::shouldReceive('getIntentWithTurnTransition')
             ->once()
             ->with($fakeTurn->getUid())
-            ->andReturn(new IntentCollection(new Intent()));
+            ->andReturn(new IntentCollection([new Intent($fakeTurn)]));
 
         $this->actingAs($this->user, 'api')
             ->json('DELETE', '/admin/api/conversation-builder/turns/' . $fakeTurn->getUid())
-            ->assertStatus(422);
+            ->assertStatus(200);
     }
 
     public function testDuplication()

--- a/tests/Feature/TurnsTest.php
+++ b/tests/Feature/TurnsTest.php
@@ -335,6 +335,32 @@ class TurnsTest extends TestCase
             ->assertStatus(422);
     }
 
+    public function testDeleteTurnByUidInUseInUse()
+    {
+        $fakeTurn = new Turn();
+        $fakeTurn->setUid('0x0001');
+        $fakeTurn->setOdId('welcome_turn');
+        $fakeTurn->setName('Welcome Turn');
+        $fakeTurn->setDescription('A welcome turn');
+
+        ConversationDataClient::shouldReceive('getTurnByUid')
+            ->once()
+            ->with($fakeTurn->getUid(), false)
+            ->andReturn($fakeTurn);
+
+        ConversationDataClient::shouldReceive('deleteTurnByUid')
+            ->never();
+
+        IntentDataClient::shouldReceive('getIntentWithTurnTransition')
+            ->once()
+            ->with($fakeTurn->getUid())
+            ->andReturn(new IntentCollection(new Intent()));
+
+        $this->actingAs($this->user, 'api')
+            ->json('DELETE', '/admin/api/conversation-builder/turns/' . $fakeTurn->getUid())
+            ->assertStatus(422);
+    }
+
     public function testDuplication()
     {
         $scenario = ScenariosTest::getFakeScenarioForDuplication();


### PR DESCRIPTION
This PR adds 3 new request classes that validate the deletion of Conversations, Scenes and Turns.

If the object being deleted is in use in a transition in any intent, a validation error is returned. The exception to this is if the intent with the transition is part of the object being deleted - in this case, the deletion can go through.

Currently, the validation error message is not very descriptive, hence this is in draft. The goal is to support a message such as:

'The conversation cannot be deleted as it is in use in 3 transitions: Conversation 1 -> Scene 1 -> Turn 1, Conversation 2 -> Scene 2 -> Turn 2 and Conversation 3 -> Scene 3 -> Turn 3