### PR TITLE
Force automatic transition deletion

### DIFF
--- a/app/Http/Controllers/API/ScenesController.php
+++ b/app/Http/Controllers/API/ScenesController.php
@@ -14,12 +14,15 @@ use App\Http\Resources\SceneResource;
 use App\Http\Resources\TurnResource;
 use App\ImportExportHelpers\PathSubstitutionHelper;
 use App\ImportExportHelpers\ScenarioImportExportHelper;
+use App\Rules\SceneInTransition;
 use Illuminate\Http\Response;
 use Illuminate\Support\Carbon;
 use OpenDialogAi\Core\Conversation\DataClients\Serializers\Normalizers\ImportExport\ScenarioNormalizer;
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
 use OpenDialogAi\Core\Conversation\Facades\SceneDataClient;
+use OpenDialogAi\Core\Conversation\Intent;
 use OpenDialogAi\Core\Conversation\Scene;
+use OpenDialogAi\Core\Conversation\Transition;
 use OpenDialogAi\Core\Conversation\Turn;
 
 class ScenesController extends Controller
@@ -97,6 +100,15 @@ class ScenesController extends Controller
      */
     public function destroy(DeleteSceneRequest $request, Scene $scene): Response
     {
+        if ($request->json('force')) {
+            $linkedIntents = SceneInTransition::getIntentsThatTransitionTo($scene->getUid());
+
+            $linkedIntents->each(function (Intent $intent) {
+                $intent->setTransition(new Transition(null, null, null));
+                ConversationDataClient::updateIntent($intent);
+            });
+        }
+
         if (ConversationDataClient::deleteSceneByUid($scene->getUid())) {
             return response()->noContent(200);
         } else {

--- a/app/Http/Requests/DeleteConversationRequest.php
+++ b/app/Http/Requests/DeleteConversationRequest.php
@@ -7,16 +7,16 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class DeleteConversationRequest extends FormRequest
 {
-    public function authorize()
-    {
-        return true;
-    }
+    use DeleteObjectRequestTrait;
 
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
     public function rules()
     {
-        return [
-            'transition_intents' => [new ConversationInTransition()]
-        ];
+        return $this->prepareRules(ConversationInTransition::class);
     }
 
     /**
@@ -24,6 +24,6 @@ class DeleteConversationRequest extends FormRequest
      */
     protected function prepareForValidation()
     {
-        $this->merge(['transition_intents' => $this->route('conversation')]);
+        $this->prepareValidation('conversation');
     }
 }

--- a/app/Http/Requests/DeleteObjectRequestTrait.php
+++ b/app/Http/Requests/DeleteObjectRequestTrait.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests;
+
+trait DeleteObjectRequestTrait
+{
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function prepareRules(string $objectRuleClass)
+    {
+        return [
+            'force' => ['boolean'],
+            'transition_intents' => [new $objectRuleClass]
+        ];
+    }
+
+    /**
+     * Fetches the conversation ID from the route param
+     */
+    protected function prepareValidation(string $routeObjectName)
+    {
+        if (!$this->json('force')) {
+            $this->merge(['transition_intents' => $this->route($routeObjectName)]);
+        }
+    }
+}

--- a/app/Http/Requests/DeleteSceneRequest.php
+++ b/app/Http/Requests/DeleteSceneRequest.php
@@ -7,15 +7,7 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class DeleteSceneRequest extends FormRequest
 {
-    /**
-     * Determine if the user is authorized to make this request.
-     *
-     * @return bool
-     */
-    public function authorize()
-    {
-        return true;
-    }
+    use DeleteObjectRequestTrait;
 
     /**
      * Get the validation rules that apply to the request.
@@ -24,9 +16,7 @@ class DeleteSceneRequest extends FormRequest
      */
     public function rules()
     {
-        return [
-            'transition_intents' => [new SceneInTransition()]
-        ];
+        return $this->prepareRules(SceneInTransition::class);
     }
 
     /**
@@ -34,6 +24,6 @@ class DeleteSceneRequest extends FormRequest
      */
     protected function prepareForValidation()
     {
-        $this->merge(['transition_intents' => $this->route('scene')]);
+        $this->prepareValidation('scene');
     }
 }

--- a/app/Http/Requests/DeleteTurnRequest.php
+++ b/app/Http/Requests/DeleteTurnRequest.php
@@ -7,15 +7,7 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class DeleteTurnRequest extends FormRequest
 {
-    /**
-     * Determine if the user is authorized to make this request.
-     *
-     * @return bool
-     */
-    public function authorize()
-    {
-        return true;
-    }
+    use DeleteObjectRequestTrait;
 
     /**
      * Get the validation rules that apply to the request.
@@ -24,9 +16,7 @@ class DeleteTurnRequest extends FormRequest
      */
     public function rules()
     {
-        return [
-            'transition_intents' => [new TurnInTransition()]
-        ];
+        return $this->prepareRules(TurnInTransition::class);
     }
 
     /**
@@ -34,6 +24,6 @@ class DeleteTurnRequest extends FormRequest
      */
     protected function prepareForValidation()
     {
-        $this->merge(['transition_intents' => $this->route('turn')]);
+        $this->prepareValidation('turn');
     }
 }

--- a/app/Rules/ConversationInTransition.php
+++ b/app/Rules/ConversationInTransition.php
@@ -5,6 +5,7 @@ namespace App\Rules;
 use OpenDialogAi\Core\Conversation\Conversation;
 use OpenDialogAi\Core\Conversation\Facades\IntentDataClient;
 use OpenDialogAi\Core\Conversation\Intent;
+use OpenDialogAi\Core\Conversation\IntentCollection;
 
 class ConversationInTransition extends BaseTransitionRule
 {
@@ -17,14 +18,21 @@ class ConversationInTransition extends BaseTransitionRule
      */
     public function passes($attribute, $value)
     {
-        $linkedIntents = IntentDataClient::getIntentWithConversationTransition($value->getUid());
+        $this->linkedIntents = self::getIntentsThatTransitionTo($value->getUid());
 
-        $linkedIntents = $linkedIntents->filter(function (Intent $intent) use ($value) {
-            return $intent->getTurn()->getScene()->getConversation()->getUid() !== $value->getUid();
+        return $this->linkedIntents->count() === 0;
+    }
+
+    /**
+     * @param string $conversationUid
+     * @return IntentCollection
+     */
+    public static function getIntentsThatTransitionTo(string $conversationUid): IntentCollection
+    {
+        $linkedIntents = IntentDataClient::getIntentWithConversationTransition($conversationUid);
+
+        return $linkedIntents->filter(function (Intent $intent) use ($conversationUid) {
+            return $intent->getTurn()->getScene()->getConversation()->getUid() !== $conversationUid;
         });
-
-        $this->linkedIntents = $linkedIntents;
-
-        return $linkedIntents->count() === 0;
     }
 }

--- a/app/Rules/SceneInTransition.php
+++ b/app/Rules/SceneInTransition.php
@@ -4,6 +4,7 @@ namespace App\Rules;
 
 use OpenDialogAi\Core\Conversation\Facades\IntentDataClient;
 use OpenDialogAi\Core\Conversation\Intent;
+use OpenDialogAi\Core\Conversation\IntentCollection;
 use OpenDialogAi\Core\Conversation\Scene;
 
 class SceneInTransition extends BaseTransitionRule
@@ -17,13 +18,21 @@ class SceneInTransition extends BaseTransitionRule
      */
     public function passes($attribute, $value)
     {
-        $linkedIntents = IntentDataClient::getIntentWithSceneTransition($value->getUid());
+        $this->linkedIntents = self::getIntentsThatTransitionTo($value->getUid());
 
-        $linkedIntents = $linkedIntents->filter(function (Intent $intent) use ($value) {
-            return $intent->getTurn()->getScene()->getUid() !== $value->getUid();
+        return $this->linkedIntents->count() === 0;
+    }
+
+    /**
+     * @param string $sceneUid
+     * @return IntentCollection
+     */
+    public static function getIntentsThatTransitionTo(string $sceneUid): IntentCollection
+    {
+        $linkedIntents = IntentDataClient::getIntentWithSceneTransition($sceneUid);
+
+        return $linkedIntents->filter(function (Intent $intent) use ($sceneUid) {
+            return $intent->getTurn()->getScene()->getUid() !== $sceneUid;
         });
-
-        $this->linkedIntents = $linkedIntents;
-        return $linkedIntents->count() === 0;
     }
 }

--- a/app/Rules/TurnInTransition.php
+++ b/app/Rules/TurnInTransition.php
@@ -4,6 +4,7 @@ namespace App\Rules;
 
 use OpenDialogAi\Core\Conversation\Facades\IntentDataClient;
 use OpenDialogAi\Core\Conversation\Intent;
+use OpenDialogAi\Core\Conversation\IntentCollection;
 use OpenDialogAi\Core\Conversation\Turn;
 
 class TurnInTransition extends BaseTransitionRule
@@ -17,13 +18,21 @@ class TurnInTransition extends BaseTransitionRule
      */
     public function passes($attribute, $value)
     {
-        $linkedIntents = IntentDataClient::getIntentWithTurnTransition($value->getUid());
+        $this->linkedIntents = self::getIntentsThatTransitionTo($value->getUid());
 
-        $linkedIntents = $linkedIntents->filter(function (Intent $intent) use ($value) {
-            return $intent->getTurn()->getUid() !== $value->getUid();
+        return $this->linkedIntents->count() === 0;
+    }
+
+    /**
+     * @param string $turnUid
+     * @return IntentCollection
+     */
+    public static function getIntentsThatTransitionTo(string $turnUid): IntentCollection
+    {
+        $linkedIntents = IntentDataClient::getIntentWithTurnTransition($turnUid);
+
+        return $linkedIntents->filter(function (Intent $intent) use ($turnUid) {
+            return $intent->getTurn()->getUid() !== $turnUid;
         });
-
-        $this->linkedIntents = $linkedIntents;
-        return $linkedIntents->count() === 0;
     }
 }


### PR DESCRIPTION
This PR adds a boolean field that can be sent to force the deletion of conversations, scenes or turns that are transitioned to. When `true` it will delete the object anyway, by deleting the transitions prior.