### PR TITLE
Spike/cli interpreter

### DIFF
--- a/app/Bot/Platform/Cli/CliMessages.php
+++ b/app/Bot/Platform/Cli/CliMessages.php
@@ -7,19 +7,25 @@ use OpenDialogAi\ResponseEngine\Message\OpenDialogMessages;
 
 class CliMessages implements OpenDialogMessages
 {
+    private array $messages = [];
 
     public function addMessage(OpenDialogMessage $message): void
     {
-        // TODO: Implement addMessage() method.
+        $this->messages[] = $message;
     }
 
     public function getMessages(): array
     {
-        // TODO: Implement getMessages() method.
+        return $this->messages;
     }
 
     public function getMessageToPost(): array
     {
-        // TODO: Implement getMessageToPost() method.
+        $messagesToPost = [];
+        foreach ($this->messages as $message) {
+            $messagesToPost[] = $message->getMessageToPost();
+        }
+
+        return $messagesToPost;
     }
 }

--- a/app/Bot/Platform/Cli/CliMessages.php
+++ b/app/Bot/Platform/Cli/CliMessages.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Bot\Platform\Cli;
+
+use OpenDialogAi\ResponseEngine\Message\OpenDialogMessage;
+use OpenDialogAi\ResponseEngine\Message\OpenDialogMessages;
+
+class CliMessages implements OpenDialogMessages
+{
+
+    public function addMessage(OpenDialogMessage $message): void
+    {
+        // TODO: Implement addMessage() method.
+    }
+
+    public function getMessages(): array
+    {
+        // TODO: Implement getMessages() method.
+    }
+
+    public function getMessageToPost(): array
+    {
+        // TODO: Implement getMessageToPost() method.
+    }
+}

--- a/app/Bot/Platform/Cli/Formatter.php
+++ b/app/Bot/Platform/Cli/Formatter.php
@@ -1,0 +1,104 @@
+<?php
+
+
+namespace App\Bot\Platform\Cli;
+
+
+use OpenDialogAi\Core\Components\ODComponentTypes;
+use OpenDialogAi\ResponseEngine\Formatters\BaseMessageFormatter;
+use OpenDialogAi\ResponseEngine\Message\AutocompleteMessage;
+use OpenDialogAi\ResponseEngine\Message\ButtonMessage;
+use OpenDialogAi\ResponseEngine\Message\DatePickerMessage;
+use OpenDialogAi\ResponseEngine\Message\EmptyMessage;
+use OpenDialogAi\ResponseEngine\Message\FormMessage;
+use OpenDialogAi\ResponseEngine\Message\FullPageFormMessage;
+use OpenDialogAi\ResponseEngine\Message\FullPageRichMessage;
+use OpenDialogAi\ResponseEngine\Message\HandToSystemMessage;
+use OpenDialogAi\ResponseEngine\Message\ImageMessage;
+use OpenDialogAi\ResponseEngine\Message\ListMessage;
+use OpenDialogAi\ResponseEngine\Message\LongTextMessage;
+use OpenDialogAi\ResponseEngine\Message\MetaMessage;
+use OpenDialogAi\ResponseEngine\Message\OpenDialogMessage;
+use OpenDialogAi\ResponseEngine\Message\OpenDialogMessages;
+use OpenDialogAi\ResponseEngine\Message\RichMessage;
+
+class Formatter extends BaseMessageFormatter
+{
+    protected static string $componentId = 'formatter.core.cli';
+    protected static string $componentSource = ODComponentTypes::CORE_COMPONENT_SOURCE;
+
+    public function getMessages(string $markup): OpenDialogMessages
+    {
+        return new CliMessages($markup);
+    }
+
+    public function generateAutocompleteMessage(array $template): AutocompleteMessage
+    {
+        // TODO: Implement generateAutocompleteMessage() method.
+    }
+
+    public function generateButtonMessage(array $template): ButtonMessage
+    {
+        // TODO: Implement generateButtonMessage() method.
+    }
+
+    public function generateEmptyMessage(): EmptyMessage
+    {
+        // TODO: Implement generateEmptyMessage() method.
+    }
+
+    public function generateFormMessage(array $template): FormMessage
+    {
+        // TODO: Implement generateFormMessage() method.
+    }
+
+    public function generateFullPageFormMessage(array $template): FullPageFormMessage
+    {
+        // TODO: Implement generateFullPageFormMessage() method.
+    }
+
+    public function generateImageMessage(array $template): ImageMessage
+    {
+        // TODO: Implement generateImageMessage() method.
+    }
+
+    public function generateListMessage(array $template): ListMessage
+    {
+        // TODO: Implement generateListMessage() method.
+    }
+
+    public function generateMetaMessage(array $template): MetaMessage
+    {
+        // TODO: Implement generateMetaMessage() method.
+    }
+
+    public function generateLongTextMessage(array $template): LongTextMessage
+    {
+        // TODO: Implement generateLongTextMessage() method.
+    }
+
+    public function generateRichMessage(array $template): RichMessage
+    {
+        // TODO: Implement generateRichMessage() method.
+    }
+
+    public function generateFullPageRichMessage(array $template): FullPageRichMessage
+    {
+        // TODO: Implement generateFullPageRichMessage() method.
+    }
+
+    public function generateTextMessage(array $template): OpenDialogMessage
+    {
+        // TODO: Implement generateTextMessage() method.
+    }
+
+    public function generateHandToSystemMessage(array $template): HandToSystemMessage
+    {
+        // TODO: Implement generateHandToSystemMessage() method.
+    }
+
+    public function generateDatePickerMessage(array $template): DatePickerMessage
+    {
+        // TODO: Implement generateDatePickerMessage() method.
+    }
+}

--- a/app/Bot/Platform/Cli/Messages/CliMessage.php
+++ b/app/Bot/Platform/Cli/Messages/CliMessage.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Bot\Platform\Cli\Messages;
+
+use OpenDialogAi\ResponseEngine\Message\OpenDialogMessage;
+
+abstract class CliMessage implements OpenDialogMessage
+{
+    protected $messageType = 'base';
+
+    const TIME = 'time';
+
+    const DATE = 'date';
+
+    /** The message text. */
+    private $text = null;
+
+    private $time;
+
+    private $date;
+
+    private $intent;
+
+    public function __construct()
+    {
+        $this->time = date('h:i A');
+        $this->date = date('D j M');
+    }
+
+    /**
+     * Sets text for a standard Web Chat message.
+     *
+     * @param $text - main message text
+     * @return $this
+     */
+    public function setText($text)
+    {
+        if (is_null($text) || $text == "") {
+            $this->text = null;
+        } else {
+            $this->text = $text;
+        }
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getText(): ?string
+    {
+        return $this->text;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTime()
+    {
+        return $this->time;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDate()
+    {
+        return $this->date;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIntent()
+    {
+        return $this->intent;
+    }
+
+    /**
+     * Set intent property
+     *
+     * @param $intent
+     * @return $this
+     */
+    public function setIntent(string $intent): OpenDialogMessage
+    {
+        $this->intent = $intent;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMessageType()
+    {
+        return $this->messageType;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getData(): ?array
+    {
+        return [
+            'text' => $this->getText(),
+            self::TIME => $this->getTime(),
+            self::DATE => $this->getDate()
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getMessageToPost()
+    {
+        return [
+            'author' => 'them',
+            'type' => $this->getMessageType(),
+            'intent' => $this->getIntent(),
+            'data' => $this->getData()
+        ];
+    }
+}

--- a/app/Bot/Platform/Cli/Messages/CliTextMessage.php
+++ b/app/Bot/Platform/Cli/Messages/CliTextMessage.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Bot\Platform\Cli\Messages;
+
+use OpenDialogAi\ResponseEngine\Message\TextMessage;
+
+class CliTextMessage extends CliMessage implements TextMessage
+{
+    protected $messageType = self::TYPE;
+
+    public function isEmpty(): bool
+    {
+        return false;
+    }
+}

--- a/app/Bot/Platform/Cli/Request.php
+++ b/app/Bot/Platform/Cli/Request.php
@@ -24,8 +24,8 @@ class Request
         $this->userId = $userId;
         $this->callbackId = $callbackId;
         $this->text = $text;
-        $this->attributeName = $attributeName;
-        $this->attributeValue = $attributeValue;
+//        $this->attributeName = $attributeName;
+//        $this->attributeValue = $attributeValue;
     }
 
     public function format()

--- a/app/Bot/Platform/Cli/Request.php
+++ b/app/Bot/Platform/Cli/Request.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Bot\Platform\Cli;
+
+class Request
+{
+    public $type;
+    public $userId;
+    public $callbackId;
+    public $text;
+    public $attributeName;
+    public $attributeValue;
+
+    /**
+     * Request constructor.
+     * @param $userId
+     * @param $callbackId
+     * @param $text
+     * @param $attributeName
+     * @param $attributeValue
+     */
+    public function __construct($userId, $callbackId = null, $text = null, $attributeName = null, $attributeValue = null)
+    {
+        $this->userId = $userId;
+        $this->callbackId = $callbackId;
+        $this->text = $text;
+        $this->attributeName = $attributeName;
+        $this->attributeValue = $attributeValue;
+    }
+
+    public function format()
+    {
+        return [
+            'user_id' => $this->userId,
+            'callback_id' => $this->callbackId,
+            'text' => $this->text,
+        ];
+    }
+}

--- a/app/Bot/Platform/Cli/Runner.php
+++ b/app/Bot/Platform/Cli/Runner.php
@@ -28,6 +28,6 @@ class Runner
         $utterance = $this->sensor->interpreter($request);
         $messageWrapper = $this->controller->runConversation($utterance);
 
-        return $messageWrapper;
+        return $messageWrapper->getMessageToPost();
     }
 }

--- a/app/Bot/Platform/Cli/Runner.php
+++ b/app/Bot/Platform/Cli/Runner.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Bot\Platform\Cli;
+
+use OpenDialogAi\Core\Controllers\OpenDialogController;
+use OpenDialogAi\ResponseEngine\Service\ResponseEngineServiceInterface;
+
+class Runner
+{
+    private OpenDialogController $controller;
+    private Sensor $sensor;
+
+    /**
+     * Runner constructor.
+     * @param OpenDialogController $controller
+     * @param Sensor $sensor
+     */
+    public function __construct(OpenDialogController $controller, Sensor $sensor)
+    {
+        $this->controller = $controller;
+        $this->sensor = $sensor;
+
+        resolve(ResponseEngineServiceInterface::class)->registerFormatter(new Formatter, true);
+    }
+
+    public function recieve(Request $request)
+    {
+        $utterance = $this->sensor->interpreter($request);
+        $messageWrapper = $this->controller->runConversation($utterance);
+
+        return $messageWrapper;
+    }
+}

--- a/app/Bot/Platform/Cli/Sensor.php
+++ b/app/Bot/Platform/Cli/Sensor.php
@@ -11,6 +11,7 @@ use OpenDialogAi\SensorEngine\BaseSensor;
 class Sensor extends BaseSensor
 {
 
+    // remove the type
     public function interpret(Request $request): UtteranceAttribute
     {
         // won't work

--- a/app/Bot/Platform/Cli/Sensor.php
+++ b/app/Bot/Platform/Cli/Sensor.php
@@ -1,0 +1,42 @@
+<?php
+
+
+namespace App\Bot\Platform\Cli;
+
+use Illuminate\Http\Request;
+use OpenDialogAi\AttributeEngine\CoreAttributes\UserAttribute;
+use OpenDialogAi\AttributeEngine\CoreAttributes\UtteranceAttribute;
+use OpenDialogAi\SensorEngine\BaseSensor;
+
+class Sensor extends BaseSensor
+{
+
+    public function interpret(Request $request): UtteranceAttribute
+    {
+        // won't work
+    }
+
+    public function interpreter(\App\Bot\Platform\Cli\Request $request): UtteranceAttribute
+    {
+        $utterance = new UtteranceAttribute('utterance');
+        $utterance
+            ->setPlatform('cli')
+            ->setUtteranceAttribute(UtteranceAttribute::UTTERANCE_DATA, $request->text)
+            ->setUtteranceAttribute(UtteranceAttribute::CALLBACK_ID, $request->callbackId)
+            ->setUtteranceAttribute(UtteranceAttribute::UTTERANCE_USER_ID, $request->userId);
+
+        $utterance->setUtteranceAttribute(
+            'utterance_user',
+            $this->createUser($request->userId)
+        );
+
+        return $utterance;
+    }
+
+    protected function createUser(string $userId): UserAttribute
+    {
+        $user = new UserAttribute(UtteranceAttribute::UTTERANCE_USER);
+        $user->setUserId($userId);
+        return $user;
+    }
+}

--- a/app/Console/Commands/Cli.php
+++ b/app/Console/Commands/Cli.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Bot\Platform\Cli\Request;
+use App\Bot\Platform\Cli\Runner;
+use GuzzleHttp\Client;
+use Illuminate\Console\Command;
+
+class Cli extends Command
+{
+    protected $signature = 'bot:run';
+
+    private Client $client;
+    private Runner $runner;
+
+    /**
+     * Cli constructor.
+     * @param Client $client
+     * @param Runner $runner
+     */
+    public function __construct(Client $client, Runner $runner)
+    {
+        $this->client = $client;
+        $this->runner = $runner;
+        parent::__construct();
+    }
+
+    public function handle()
+    {
+        $userId = $this->ask('Hello, who are you?');
+
+        $this->output->writeln("<info>Identified {$userId}</info>");
+
+        $request = new Request($userId, 'WELCOME');
+
+        $response = $this->sendRequest($request);
+
+        $this->info($response->);
+
+
+//        $chatRequest = $this->createWebchatRequest($user, 'trigger', $openingIntent);
+//
+//        while (!empty($chatRequest)) {
+//            // Get the Utterance.
+//            $utterance = $webChatSensor->interpret($chatRequest);
+//
+//            /** @var WebChatMessages $messageWrapper */
+//            $messageWrapper = $odController->runConversation($utterance);
+//
+//            $messages = $messageWrapper->getMessageToPost();
+//
+//            $chatRequest = $this->renderMessages($user, $messages);
+//        }
+//
+//        $this->output->writeln("<comment>The end</comment>");
+    }
+
+    protected function createWebchatRequest($user, $type, $intent = '', $text = '', $value = '')
+    {
+        $chatData = [
+            'notification' => 'message',
+            'user_id' => $user->email,
+            'author' => $user->email,
+            'content' => [
+                'type' => $type,
+                'author' => $user->email,
+                'callback_id' => $intent,
+                'data' => [
+                    'text' => $text,
+                    'value' => $value,
+                    'date' => "Wed 16 Dec",
+                    'time' => "11:50:40 AM",
+                ],
+                'mode' => 'webchat',
+                'modeInstance' => 0,
+                'user_id' => $user->email,
+                'user' => [
+                    "first_name" => $user->name,
+                    "last_name" => "",
+                    "email" => $user->email,
+                    "external_id" => $user->id,
+                ]
+            ]
+        ];
+
+        return $this->createRequest('POST', json_encode($chatData));
+    }
+
+    /**
+     * @param $user
+     * @param $messages
+     *
+     * @return \Illuminate\Http\Request|\Symfony\Component\HttpFoundation\Request|void
+     */
+    protected function renderMessages($user, $messages)
+    {
+        if (empty($messages)) {
+            $this->output->writeln("<info>Empty list of messages</info>");
+            return;
+        }
+
+        foreach ($messages as $message) {
+            $response = $this->renderMessage($user, $message);
+
+            if (!empty($response)) {
+                return $response;
+            }
+        }
+
+        $freeTextResponse = $this->ask('');
+        return $this->createWebchatRequest($user, 'text', '', $freeTextResponse);
+    }
+
+    protected function renderMessage($user, $message)
+    {
+        if (empty($message)) {
+            $this->output->writeln("<info>Empty response</info>");
+            return null;
+        }
+
+        $this->output->writeln("\n------------------------------------------------------------\n"
+            . "<info>{$message['type']} message ({$message['intent']})</info>");
+
+        if ($this->output->isVerbose()) {
+            print_r($message);
+        }
+
+        switch ($message['type']) {
+            case 'button':
+                $optionsText = '';
+                $options = [];
+
+                foreach ($message['data']['buttons'] as $id => $button) {
+                    $optionsText .= "   > {$button['text']} ({$button['callback_id']})\n";
+                    $options[] = $button['text'];
+                }
+
+                $result = $this->askWithCompletion("<comment>{$message['data']['text']}</comment>"
+                    . "\n<info> Button options:\n{$optionsText}</info>", $options, $message['data']['buttons'][0]['text']);
+                $choice = array_search($result, $options);
+
+                if ($choice === false) {
+                    $this->output->writeln("<error>Foolish human! That was not an option.</error>");
+                    return null;
+                }
+
+                return $this->createWebchatRequest(
+                    $user,
+                    'button_response',
+                    $message['data']['buttons'][$choice]['callback_id'],
+                    $message['data']['buttons'][$choice]['text']
+                );
+
+            case 'text':
+                $this->output->writeln("<comment>{$message['data']['text']}</comment>");
+                break;
+
+            default:
+                $this->output->writeln("<error>CLI cannot deal with a {$message['type']} response</error>");
+                break;
+        }
+    }
+
+    public function sendRequest(Request $request)
+    {
+        return $this->runner->recieve($request);
+    }
+}
+


### PR DESCRIPTION
This is a POC minimal implementation of a separate (but super simple) platform integration that works through the command line.

There is a new command that can be started with `bot:run` 

It will ask the user for their id and then send a WELCOME request. There is no way of setting a scenario id currently, so this will only work on a scenario if there are no scenario conditions.

The custom CLI classes created:
- Request: to store all the info that could be in a request sent to the conversation engine. This is much simplified over what webchat sends, but currently does not include any extra user context other than the user-id
- CliMessage: The base message class that contains all common message fields
- CliTextMessae: A text message implementation of a CliMessage - this is the only one implemented at the moment
- Formatter: This takes OD message XML and converts to the correct CLI message. There is a lot of repetition here with what webchat does  
- Sensor that takes a CLI request and turns it into an Utterance Attribute (not the required 'interpret' method specifies that it needs an HTTP request object)

There is a breakdown of work required in this doc https://docs.google.com/document/d/1XLGWFqWgRZElWcSK5rwhlM7E6yy49aJDdE-HGbqnCPw

Most pressing to help with the issues of repetition above are:
- Extract any XML parsing into the base message formatter
- Convert XML strings into concrete classes to pass into the platform specific message formatters
- Base formatter to handle attribute messages
