### PR TITLE
Platform configuration fix

### DIFF
--- a/app/Console/Commands/ConfigurationUpdates/Updates/CreateWebchatPlatforms.php
+++ b/app/Console/Commands/ConfigurationUpdates/Updates/CreateWebchatPlatforms.php
@@ -171,7 +171,7 @@ class CreateWebchatPlatforms extends BaseConfigurationUpdate
     {
         $table = DB::table('webchat_settings');
 
-        if ($table->exists() && $table->count() > 0) {
+        if ($table->exists() && $table->count() > 0 && $table->where('value', '<>', '')->count() > 0) {
             return $this->convertSettingsToArray();
         } else {
             $odUrl = $this->option('url') ? $this->option('url') : env('APP_URL');

--- a/app/Console/Commands/ConfigurationUpdates/Updates/CreateWebchatPlatforms.php
+++ b/app/Console/Commands/ConfigurationUpdates/Updates/CreateWebchatPlatforms.php
@@ -3,7 +3,6 @@
 namespace App\Console\Commands\ConfigurationUpdates\Updates;
 
 use App\Console\Commands\ConfigurationUpdates\BaseConfigurationUpdate;
-use Exception;
 use Illuminate\Support\Facades\DB;
 use OpenDialogAi\Core\Components\Configuration\ComponentConfiguration;
 use OpenDialogAi\Core\Components\Configuration\ConfigurationDataHelper;
@@ -31,10 +30,6 @@ class CreateWebchatPlatforms extends BaseConfigurationUpdate
      */
     public function beforeUp(): bool
     {
-        if (!$this->checkConfigurationsAreScopedByScenario()) {
-            return false;
-        }
-
         $this->warn("Webchat settings are deprecated, they should now be stored as platform configuration"
             . " for each scenario. Please convert your webchat settings.");
 
@@ -107,24 +102,6 @@ class CreateWebchatPlatforms extends BaseConfigurationUpdate
             'configuration' => $configuration,
             'active' => true,
         ]);
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function checkConfigurationsAreScopedByScenario(): bool
-    {
-        $validConfiguration = ComponentConfiguration::where(['name' => ConfigurationDataHelper::OPENDIALOG_INTERPRETER])
-            ->where('scenario_id', '<>', '')
-            ->first();
-
-        if (is_null($validConfiguration)) {
-            throw new Exception("Check unsuccessful: Configurations aren't all scoped by scenario,"
-                . " please ensure you have run all necessary updates");
-        } else {
-            $this->info("Check successful: Configurations are all scoped by scenario.");
-            return true;
-        }
     }
 
     private function convertSettingsToArray(): array

--- a/app/Console/Commands/ConfigurationUpdates/Updates/ScopeConfigurationsByScenario.php
+++ b/app/Console/Commands/ConfigurationUpdates/Updates/ScopeConfigurationsByScenario.php
@@ -29,7 +29,7 @@ class ScopeConfigurationsByScenario extends BaseConfigurationUpdate
         $numOfConfigurations = ComponentConfiguration::count();
 
         $this->warn("Configurations are now scenario specific, please duplicate your existing configurations"
-            . "for each scenario and delete the outdated non-specific configurations.");
+            . " for each scenario and delete the outdated non-specific configurations.");
 
         $duplicateConfirm = sprintf(
             'Are you sure you want to duplicate all %d configurations for all %d scenarios, and then delete'

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "laravel/tinker": "^2.6",
         "laravel/ui": "^3.2",
         "maennchen/zipstream-php": "^2.0",
-        "opendialogai/core": "1.x-dev",
+        "opendialogai/core": "dev-fix/platform-config",
         "opendialogai/dgraph-docker": "21.03.0.2",
         "opendialogai/webchat": "1.x-dev",
         "phalcongelist/php-diff": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "laravel/tinker": "^2.6",
         "laravel/ui": "^3.2",
         "maennchen/zipstream-php": "^2.0",
-        "opendialogai/core": "dev-fix/platform-config",
+        "opendialogai/core": "1.x-dev",
         "opendialogai/dgraph-docker": "21.03.0.2",
         "opendialogai/webchat": "1.x-dev",
         "phalcongelist/php-diff": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cfbfdc0fefb7afc79be077b6ec323f11",
+    "content-hash": "e1213c1d6a8fec7869b749fa8a91a364",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2916,16 +2916,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "dev-fix/platform-config",
+            "version": "1.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "1216366d827781fadd1f9712742cb08f9399334f"
+                "reference": "a9dbd11921f58d5a2f8f778259d9a5cb09fa7afb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/1216366d827781fadd1f9712742cb08f9399334f",
-                "reference": "1216366d827781fadd1f9712742cb08f9399334f",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/a9dbd11921f58d5a2f8f778259d9a5cb09fa7afb",
+                "reference": "a9dbd11921f58d5a2f8f778259d9a5cb09fa7afb",
                 "shasum": ""
             },
             "require": {
@@ -2952,6 +2952,7 @@
                 "phpunit/phpunit": "^9.0",
                 "squizlabs/php_codesniffer": "^3.4"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -3003,9 +3004,9 @@
             "description": "The OpenDialog Core package",
             "support": {
                 "issues": "https://github.com/opendialogai/core/issues",
-                "source": "https://github.com/opendialogai/core/tree/fix/platform-config"
+                "source": "https://github.com/opendialogai/core/tree/1.x"
             },
-            "time": "2021-09-02T11:02:20+00:00"
+            "time": "2021-09-02T13:29:04+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e1213c1d6a8fec7869b749fa8a91a364",
+    "content-hash": "cfbfdc0fefb7afc79be077b6ec323f11",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2916,16 +2916,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "1.x-dev",
+            "version": "dev-fix/platform-config",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "f9c919b73cb02bd0edfb80da7a1e33c977945852"
+                "reference": "1216366d827781fadd1f9712742cb08f9399334f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/f9c919b73cb02bd0edfb80da7a1e33c977945852",
-                "reference": "f9c919b73cb02bd0edfb80da7a1e33c977945852",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/1216366d827781fadd1f9712742cb08f9399334f",
+                "reference": "1216366d827781fadd1f9712742cb08f9399334f",
                 "shasum": ""
             },
             "require": {
@@ -2952,7 +2952,6 @@
                 "phpunit/phpunit": "^9.0",
                 "squizlabs/php_codesniffer": "^3.4"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -3004,9 +3003,9 @@
             "description": "The OpenDialog Core package",
             "support": {
                 "issues": "https://github.com/opendialogai/core/issues",
-                "source": "https://github.com/opendialogai/core/tree/1.x"
+                "source": "https://github.com/opendialogai/core/tree/fix/platform-config"
             },
-            "time": "2021-08-31T10:36:13+00:00"
+            "time": "2021-09-02T11:02:20+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",


### PR DESCRIPTION
This PR is dependent on https://github.com/opendialogai/core/pull/557 and removes an unnecessary check from the webchat platform configuration update class, which was not previously accounting for _new_ applications (which will have no scenarios by default).