### PR TITLE
Including configurations in scenario import & export

### DIFF
--- a/app/Console/Commands/Specification/ExportScenarios.php
+++ b/app/Console/Commands/Specification/ExportScenarios.php
@@ -3,11 +3,8 @@
 
 namespace App\Console\Commands\Specification;
 
-use App\Console\Facades\ImportExportSerializer;
-use App\ImportExportHelpers\PathSubstitutionHelper;
 use App\ImportExportHelpers\ScenarioImportExportHelper;
 use Illuminate\Console\Command;
-use OpenDialogAi\Core\Conversation\DataClients\Serializers\Normalizers\ImportExport\ScenarioNormalizer;
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
 use OpenDialogAi\Core\Conversation\Facades\ScenarioDataClient;
 use OpenDialogAi\Core\Conversation\Scenario;
@@ -32,9 +29,7 @@ class ExportScenarios extends Command
     public function exportScenario(Scenario $fullScenarioGraph)
     {
         $filePath = ScenarioImportExportHelper::getScenarioFilePath($fullScenarioGraph->getOdId());
-        $serialized = ImportExportSerializer::serialize($fullScenarioGraph, 'json', [
-            ScenarioNormalizer::UID_MAP => PathSubstitutionHelper::createScenarioMap($fullScenarioGraph)
-        ]);
+        $serialized = ScenarioImportExportHelper::getSerializedData($fullScenarioGraph);
 
         if (ScenarioImportExportHelper::scenarioFileExists($filePath)) {
             $this->info(sprintf("Scenario file at %s already exists. Deleting...", $filePath));

--- a/app/Console/Commands/Specification/ImportScenarios.php
+++ b/app/Console/Commands/Specification/ImportScenarios.php
@@ -2,7 +2,6 @@
 
 namespace App\Console\Commands\Specification;
 
-use App\Http\Controllers\API\ScenariosController;
 use App\ImportExportHelpers\ScenarioImportExportHelper;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
@@ -36,8 +35,7 @@ class ImportScenarios extends Command
         }
 
         try {
-            $scenario = ScenarioImportExportHelper::importScenarioFromString($scenarioData);
-            ScenariosController::createDefaultConfigurationsForScenario($scenario->getUid());
+            ScenarioImportExportHelper::importScenarioFromString($scenarioData);
         } catch (NotEncodableValueException $e) {
             $this->error(sprintf("Import of %s failed. Unable to decode file as json", $filePath));
             return;

--- a/tests/specification/scenarios/example_scenario.scenario.json
+++ b/tests/specification/scenarios/example_scenario.scenario.json
@@ -100,5 +100,131 @@
             ]
 
         }
+    ],
+    "configurations": [
+        {
+            "name": "Dialogflow",
+            "scenario_id": "$path:example_scenario",
+            "component_id": "interpreter.core.dialogflow",
+            "configuration": {
+                "intents": {
+                    "Knowledge.KnowledgeBase.*": "intent.dialogflow.faq"
+                },
+                "entities": {
+                    "": ""
+                },
+                "json_key": {},
+                "project_id": "dialogflow-test",
+                "environment": "draft",
+                "language_code": "en_gb"
+            },
+            "active": true
+        },
+        {
+            "name": "OpenDialog",
+            "scenario_id": "$path:example_scenario",
+            "component_id": "interpreter.core.opendialog",
+            "configuration": {
+                "callbacks": {
+                    "WELCOME": "intent.core.welcome"
+                },
+                "enable_similarity_evaluation": true
+            },
+            "active": true
+        },
+        {
+            "name": "Webchat",
+            "scenario_id": "$path:example_scenario",
+            "component_id": "platform.core.webchat",
+            "configuration": {
+                "colours": {
+                    "buttonText": "#1b2956",
+                    "headerText": "#ffffff",
+                    "userInputText": "#1b212a",
+                    "iconBackground": "0000ff",
+                    "sentMessageText": "#1b2956",
+                    "buttonBackground": "#7fdad1",
+                    "headerBackground": "#1b2956",
+                    "externalButtonText": "#1b2956",
+                    "launcherBackground": "#1b2956",
+                    "iconHoverBackground": "ffffff",
+                    "receivedMessageText": "#1b2956",
+                    "userInputBackground": "#ffffff",
+                    "buttonHoverBackground": "#7fdad1",
+                    "messageListBackground": "#1b2956",
+                    "sentMessageBackground": "#7fdad1",
+                    "externalButtonBackground": "#7fdad1",
+                    "receivedMessageBackground": "#ffffff",
+                    "externalButtonHoverBackground": "#7fdad1"
+                },
+                "general": {
+                    "url": "https:\/\/opendialog.test\/web-chat",
+                    "logo": "https:\/\/opendialog.test\/images\/homepage-logo.svg",
+                    "open": true,
+                    "teamName": "",
+                    "validPath": [
+                        "*"
+                    ],
+                    "useBotName": false,
+                    "chatbotName": "OpenDialog",
+                    "pageCssPath": "",
+                    "messageDelay": "500",
+                    "useBotAvatar": true,
+                    "useHumanName": false,
+                    "collectUserIp": true,
+                    "chatbotCssPath": "",
+                    "useHumanAvatar": false,
+                    "hideMessageTime": true,
+                    "disableCloseChat": false,
+                    "formResponseText": null,
+                    "messageAnimation": false,
+                    "chatbotAvatarPath": "https:\/\/opendialog.test\/vendor\/webchat\/images\/avatar.svg",
+                    "showEndChatButton": false,
+                    "showRestartButton": false,
+                    "showDownloadButton": true,
+                    "hideDatetimeMessage": true,
+                    "newUserOpenCallback": "WELCOME",
+                    "typingIndicatorStyle": "",
+                    "newUserStartMinimized": false,
+                    "restartButtonCallback": "intent.core.restart",
+                    "showHeaderCloseButton": false,
+                    "chatbotFullpageCssPath": "",
+                    "ongoingUserOpenCallback": "",
+                    "scrollToFirstNewMessage": false,
+                    "ongoingUserStartMinimized": false,
+                    "returningUserOpenCallback": "WELCOME",
+                    "returningUserStartMinimized": false,
+                    "showTextInputWithExternalButtons": false,
+                    "showHeaderButtonsOnFullPageMessages": false,
+                    "hideTypingIndicatorOnInternalMessages": false
+                },
+                "comments": {
+                    "commentsName": "Comments",
+                    "commentsEnabled": false,
+                    "commentsEndpoint": "http:\/\/example.com\/json-api\/v1",
+                    "commentsAuthToken": "Bearer ApiTokenValue",
+                    "commentsEntityName": "comments",
+                    "commentsTextFieldName": "comment",
+                    "commentsAuthorEntityName": "users",
+                    "commentsCreatedFieldName": "created-at",
+                    "commentsAuthorIdFieldName": "id",
+                    "commentsSectionEntityName": "posts",
+                    "commentsEnabledPathPattern": "^\\\/home\\\/posts",
+                    "commentsSectionFilterQuery": "post",
+                    "commentsSectionIdFieldName": "id",
+                    "commentsSectionPathPattern": "home\\\/posts\\\/\\d*$",
+                    "commentsAuthorNameFieldName": "name",
+                    "commentsSectionNameFieldName": "name",
+                    "commentsAuthorRelationshipName": "author",
+                    "commentsSectionRelationshipName": "post",
+                    "commentsSectionFilterPathPattern": "home\\\/posts\\\/(\\d*)\\\/?"
+                },
+                "webchatHistory": {
+                    "showHistory": true,
+                    "numberOfMessages": 10
+                }
+            },
+            "active": true
+        }
     ]
 }

--- a/tests/specification/scenarios/minimal_scenario.scenario.json
+++ b/tests/specification/scenarios/minimal_scenario.scenario.json
@@ -5,5 +5,25 @@
     "interpreter": "",
     "behaviors": [],
     "conditions": [],
-    "conversations": []
+    "conversations": [],
+    "configurations": [
+        {
+            "name": "OpenDialog",
+            "scenario_id": "$path:minimal_scenario",
+            "component_id": "interpreter.core.opendialog",
+            "configuration": {
+                "callbacks": {
+                    "WELCOME": "intent.core.welcome"
+                }
+            },
+            "active": true
+        },
+        {
+            "name": "Webchat",
+            "scenario_id": "$path:minimal_scenario",
+            "component_id": "platform.core.webchat",
+            "configuration": {},
+            "active": true
+        }
+    ]
 }


### PR DESCRIPTION
This PR includes configuration data in the import / export files of scenarios. To be backward compability, if an imported file doesn't have any configurations (ie. all pre-existing configurations), then the two default configurations (OpenDialog interpreter & Webchat platform) will be created.