### PR TITLE
Feature/fetch css content

### DIFF
--- a/app/Http/Controllers/API/ExternalCssController.php
+++ b/app/Http/Controllers/API/ExternalCssController.php
@@ -4,37 +4,24 @@ namespace App\Http\Controllers\API;
 
 use GuzzleHttp\Client;
 use Illuminate\Http\Request;
-use OpenDialogAi\Core\Components\Configuration\ComponentConfiguration;
 
 class ExternalCssController
 {
-    public function getScenarioCss($scenarioId)
-    {
-        $client = new Client();
-        $query = ComponentConfiguration::query()
-            ->platforms()
-            ->byScenario($scenarioId);
-
-        $path = $query->first()->configuration['general']['chatbotCssPath'];
-
-        if ($path) {
-            return $client->get($path)
-                ->getBody()
-                ->getContents();
-        }
-
-        return response()->setStatusCode(404);
-    }
-
     public function getCss(Request $request)
     {
         $client = new Client();
-        $path = $request->get('path');
+        try {
+            $path = $request->get('path');
 
-        if ($path) {
-            return $client->get($path)
-                ->getBody()
-                ->getContents();
+            if ($path) {
+                return $client->get($path)
+                    ->getBody()
+                    ->getContents();
+            }
+        } catch (\Exception $e) {
+            return response()
+                ->setContent(sprintf("Error fetching css content - %s", $e->getMessage()))
+                ->setStatusCode(400);
         }
 
         return response()->setStatusCode(404);

--- a/app/Http/Controllers/API/ExternalCssController.php
+++ b/app/Http/Controllers/API/ExternalCssController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use GuzzleHttp\Client;
+use Illuminate\Http\Request;
+use OpenDialogAi\Core\Components\Configuration\ComponentConfiguration;
+
+class ExternalCssController
+{
+    public function getScenarioCss($scenarioId)
+    {
+        $client = new Client();
+        $query = ComponentConfiguration::query()
+            ->platforms()
+            ->byScenario($scenarioId);
+
+        $path = $query->first()->configuration['general']['chatbotCssPath'];
+
+        if ($path) {
+            return $client->get($path)
+                ->getBody()
+                ->getContents();
+        }
+
+        return response()->setStatusCode(404);
+    }
+
+    public function getCss(Request $request)
+    {
+        $client = new Client();
+        $path = $request->get('path');
+
+        if ($path) {
+            return $client->get($path)
+                ->getBody()
+                ->getContents();
+        }
+
+        return response()->setStatusCode(404);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -157,4 +157,7 @@ Route::namespace('API')
 
         Route::get('/templates', 'TemplateController@index');
         Route::get('/templates/{id}', 'TemplateController@show');
+
+        Route::get('/scenario/{scenarioId}/css', 'ExternalCssController@getScenarioCss');
+        Route::post('/external-css', 'ExternalCssController@getCss');
     });

--- a/routes/api.php
+++ b/routes/api.php
@@ -158,6 +158,5 @@ Route::namespace('API')
         Route::get('/templates', 'TemplateController@index');
         Route::get('/templates/{id}', 'TemplateController@show');
 
-        Route::get('/scenario/{scenarioId}/css', 'ExternalCssController@getScenarioCss');
-        Route::post('/external-css', 'ExternalCssController@getCss');
+        Route::get('/external-css', 'ExternalCssController@getCss');
     });

--- a/tests/Feature/CssApiTest.php
+++ b/tests/Feature/CssApiTest.php
@@ -32,6 +32,13 @@ class CssApiTest extends TestCase
         $data = ['path' => 'http://path-to.css'];
         $this->actingAs($this->user, 'api')
             ->json("GET", '/admin/api/external-css', $data)
+            ->assertStatus(400);
+    }
+
+    public function testGetExternalCssNoPath()
+    {
+        $this->actingAs($this->user, 'api')
+            ->json("GET", '/admin/api/external-css')
             ->assertStatus(404);
     }
 

--- a/tests/Feature/CssApiTest.php
+++ b/tests/Feature/CssApiTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Controllers\API\ExternalCssController;
+use App\User;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Tests\TestCase;
+
+class CssApiTest extends TestCase
+{
+    protected $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->user = factory(User::class)->create();
+    }
+
+    public function testGetExternalCssNotAuthed()
+    {
+        $data = ['path' => 'http://path-to.css'];
+        $this->json("GET", '/admin/api/external-css', $data)
+            ->assertStatus(401);
+    }
+
+    public function testGetExternalCssNotFound()
+    {
+        $data = ['path' => 'http://path-to.css'];
+        $this->actingAs($this->user, 'api')
+            ->json("GET", '/admin/api/external-css', $data)
+            ->assertStatus(404);
+    }
+
+    public function testGetExternalCssWrongType()
+    {
+        $this->app->bind(ExternalCssController::class, function () {
+            $mock = new MockHandler([
+                new Response(200, ['Content-Type' => 'not-css'], "")
+            ]);
+
+            $handler = HandlerStack::create($mock);
+
+            return new ExternalCssController(new Client(['handler' => $handler]));
+        });
+
+        $data = ['path' => 'http://path-to.css'];
+        $this->actingAs($this->user, 'api')
+            ->json("GET", '/admin/api/external-css', $data)
+            ->assertStatus(400);
+    }
+
+    public function testGetExternalCssSuccess()
+    {
+        $css = "{css}";
+        $this->app->bind(ExternalCssController::class, function () use ($css) {
+            $mock = new MockHandler([
+                new Response(200, ['Content-Type' => 'text/css'], $css)
+            ]);
+
+            $handler = HandlerStack::create($mock);
+
+            return new ExternalCssController(new Client(['handler' => $handler]));
+        });
+
+        $data = ['path' => 'http://path-to.css'];
+        $this->actingAs($this->user, 'api')
+            ->json("GET", '/admin/api/external-css', $data)
+            ->assertStatus(200)
+            ->assertSeeText($css);
+    }
+}


### PR DESCRIPTION
This PR adds a new endpoint that can be used to fetch external css content. This is used by the front end to update live preview of the webchat component when someone adds an external css file