### PR TITLE
Adding list of message template IDs to all intent responses

### DIFF
--- a/app/Http/Resources/ConversationResource.php
+++ b/app/Http/Resources/ConversationResource.php
@@ -8,6 +8,7 @@ use OpenDialogAi\Core\Conversation\Behavior;
 use OpenDialogAi\Core\Conversation\Condition;
 use OpenDialogAi\Core\Conversation\Conversation;
 use OpenDialogAi\Core\Conversation\Intent;
+use OpenDialogAi\Core\Conversation\MessageTemplate;
 use OpenDialogAi\Core\Conversation\Scene;
 use OpenDialogAi\Core\Conversation\Turn;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
@@ -46,13 +47,19 @@ class ConversationResource extends JsonResource
                         Intent::UID,
                         Intent::NAME,
                         Intent::SAMPLE_UTTERANCE,
-                        Intent::SPEAKER
+                        Intent::SPEAKER,
+                        Intent::MESSAGE_TEMPLATES => [
+                            MessageTemplate::UID,
+                        ]
                     ],
                     Turn::RESPONSE_INTENTS => [
                         Intent::UID,
                         Intent::NAME,
                         Intent::SAMPLE_UTTERANCE,
                         Intent::SPEAKER,
+                        Intent::MESSAGE_TEMPLATES => [
+                            MessageTemplate::UID,
+                        ]
                     ],
                 ]
             ]

--- a/app/Http/Resources/FocusedTurnResource.php
+++ b/app/Http/Resources/FocusedTurnResource.php
@@ -9,6 +9,7 @@ use OpenDialogAi\Core\Conversation\Behavior;
 use OpenDialogAi\Core\Conversation\Condition;
 use OpenDialogAi\Core\Conversation\Conversation;
 use OpenDialogAi\Core\Conversation\Intent;
+use OpenDialogAi\Core\Conversation\MessageTemplate;
 use OpenDialogAi\Core\Conversation\Scenario;
 use OpenDialogAi\Core\Conversation\Scene;
 use OpenDialogAi\Core\Conversation\Turn;
@@ -45,6 +46,9 @@ class FocusedTurnResource extends JsonResource
                 Intent::SPEAKER,
                 Intent::BEHAVIORS => Behavior::FIELDS,
                 Intent::CONDITIONS => Condition::FIELDS,
+                Intent::MESSAGE_TEMPLATES => [
+                    MessageTemplate::UID,
+                ]
             ],
             Turn::RESPONSE_INTENTS => [
                 Intent::UID,
@@ -55,6 +59,9 @@ class FocusedTurnResource extends JsonResource
                 Intent::SPEAKER,
                 Intent::BEHAVIORS => Behavior::FIELDS,
                 Intent::CONDITIONS => Condition::FIELDS,
+                Intent::MESSAGE_TEMPLATES => [
+                    MessageTemplate::UID,
+                ]
             ],
             Turn::SCENE => [
                 Scene::UID,

--- a/app/Http/Resources/IntentResource.php
+++ b/app/Http/Resources/IntentResource.php
@@ -9,6 +9,7 @@ use OpenDialogAi\Core\Conversation\Action;
 use OpenDialogAi\Core\Conversation\Behavior;
 use OpenDialogAi\Core\Conversation\Condition;
 use OpenDialogAi\Core\Conversation\Intent;
+use OpenDialogAi\Core\Conversation\MessageTemplate;
 use OpenDialogAi\Core\Conversation\Transition;
 use OpenDialogAi\Core\Conversation\VirtualIntent;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
@@ -37,7 +38,10 @@ class IntentResource extends JsonResource
             Intent::BEHAVIORS => Behavior::FIELDS,
             Intent::CONDITIONS => Condition::FIELDS,
             Intent::TRANSITION,
-            Intent::ACTIONS => Action::FIELDS
+            Intent::ACTIONS => Action::FIELDS,
+            Intent::MESSAGE_TEMPLATES => [
+                MessageTemplate::UID,
+            ],
         ]
     ];
 

--- a/app/Http/Resources/TurnResource.php
+++ b/app/Http/Resources/TurnResource.php
@@ -32,13 +32,19 @@ class TurnResource extends JsonResource
                 Intent::UID,
                 Intent::NAME,
                 Intent::SAMPLE_UTTERANCE,
-                Intent::SPEAKER
+                Intent::SPEAKER,
+                Intent::MESSAGE_TEMPLATES => [
+                    MessageTemplate::UID,
+                ]
             ],
             Turn::RESPONSE_INTENTS => [
                 Intent::UID,
                 Intent::NAME,
                 Intent::SAMPLE_UTTERANCE,
                 Intent::SPEAKER,
+                Intent::MESSAGE_TEMPLATES => [
+                    MessageTemplate::UID,
+                ]
             ],
         ]
     ];

--- a/tests/Feature/UIStateControllerTest.php
+++ b/tests/Feature/UIStateControllerTest.php
@@ -14,6 +14,8 @@ use OpenDialogAi\Core\Conversation\Exceptions\ConversationObjectNotFoundExceptio
 use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
 use OpenDialogAi\Core\Conversation\Intent;
 use OpenDialogAi\Core\Conversation\IntentCollection;
+use OpenDialogAi\Core\Conversation\MessageTemplate;
+use OpenDialogAi\Core\Conversation\MessageTemplateCollection;
 use OpenDialogAi\Core\Conversation\Scenario;
 use OpenDialogAi\Core\Conversation\Scene;
 use OpenDialogAi\Core\Conversation\SceneCollection;
@@ -268,6 +270,34 @@ class UIStateControllerTest extends TestCase
     {
         $fakeTurn = $this->createFakeConversation('0x0001', '0x0002', '0x0003', '0x0004');
 
+        $fakeIntent = new Intent($fakeTurn);
+        $fakeIntent->setUid('0x0004');
+        $fakeIntent->setOdId('first_intent');
+        $fakeIntent->setName('First intent');
+        $fakeIntent->setDescription('The first intent');
+        $fakeIntent->setCreatedAt($fakeTurn->getCreatedAt());
+        $fakeIntent->setUpdatedAt($fakeTurn->getUpdatedAt());
+
+        $fakeTurn->setRequestIntents(new IntentCollection([$fakeIntent]));
+
+        $message1 = new MessageTemplate();
+        $message1->setIntent($fakeIntent);
+        $message1->setUid('0x0005');
+        $message1->setOdId('first');
+        $message1->setName('First');
+        $message1->setCreatedAt($fakeIntent->getCreatedAt());
+        $message1->setUpdatedAt($fakeIntent->getUpdatedAt());
+
+        $message2 = new MessageTemplate();
+        $message2->setIntent($fakeIntent);
+        $message2->setUid('0x0006');
+        $message2->setOdId('second');
+        $message2->setName('Second');
+        $message2->setCreatedAt($fakeIntent->getCreatedAt());
+        $message2->setUpdatedAt($fakeIntent->getUpdatedAt());
+
+        $fakeIntent->setMessageTemplates(new MessageTemplateCollection([$message1, $message2]));
+
         ConversationDataClient::shouldReceive('getTurnByUid')
             ->once()
             ->with($fakeTurn->getUid(), false)
@@ -306,9 +336,28 @@ class UIStateControllerTest extends TestCase
                                 "created_at"=> "2021-02-24T09:30:00+0000",
                                 "behaviors" => [],
                                 "conditions" => [],
-                                "intents" => []
+                                "intents" => [
+                                    [
+                                        "order" => "REQUEST",
+                                        "intent" => [
+                                            "id" => "0x0004",
+                                            "od_id" => "first_intent",
+                                            "name" => "First intent",
+                                            "description" => "The first intent",
+                                            "behaviors" => [],
+                                            "conditions" => [],
+                                            "message_templates" => [
+                                                [
+                                                    "id" => "0x0005",
+                                                ],
+                                                [
+                                                    "id" => "0x0006",
+                                                ]
+                                            ]
+                                        ]
+                                    ]
+                                ]
                             ]
-
                         ]
                     ]
                 ]
@@ -476,6 +525,7 @@ class UIStateControllerTest extends TestCase
                             "speaker" => "USER",
                             "behaviors" => [],
                             "conditions" => [],
+                            "message_templates" => [],
                         ],
                         "order" => "RESPONSE"
                     ],
@@ -489,6 +539,7 @@ class UIStateControllerTest extends TestCase
                             "speaker" => "APP",
                             "behaviors" => [],
                             "conditions" => [],
+                            "message_templates" => [],
                         ],
                         "order" => "REQUEST"
                     ]


### PR DESCRIPTION
This PR adds a list of message template IDs to all intent responses, which provides the ability to count the number of message templates associated with each intent.