### PR TITLE
Adding meta data for focused object responses

### DIFF
--- a/app/Http/Resources/FocusedSceneResource.php
+++ b/app/Http/Resources/FocusedSceneResource.php
@@ -152,11 +152,17 @@ class FocusedSceneResource extends JsonResource
             ->map(fn ($i) => $i['intent']);
 
         $intentsWithOutgoingTransition = $intents
-            ->filter(fn ($i) => !is_null($i['transition']) || !is_null($i['transition']['conversation']));
+            ->filter(fn ($i) => !is_null($i['transition']) && !is_null($i['transition']['conversation']))
+            ->values();
+
+        $intentsWithCompletingBehaviour = $intents
+            ->filter(fn ($i) => in_array(Behavior::COMPLETING_BEHAVIOR, $i['behaviors']))
+            ->values();
 
         $data['scenario']['conversation']['focusedScene']['_meta'] = [
             'incoming_transitions' => $intentsWithTransitionToConversation,
             'outgoing_transitions' => $intentsWithOutgoingTransition,
+            'completing_intents' => $intentsWithCompletingBehaviour,
         ];
 
         return $data;

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "laravel/tinker": "^2.6",
         "laravel/ui": "^3.2",
         "maennchen/zipstream-php": "^2.0",
-        "opendialogai/core": "dev-feature/OPNDLG-1017--transition-completing-data",
+        "opendialogai/core": "1.x-dev",
         "opendialogai/dgraph-docker": "21.03.0.2",
         "opendialogai/webchat": "1.2.0",
         "phalcongelist/php-diff": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "laravel/tinker": "^2.6",
         "laravel/ui": "^3.2",
         "maennchen/zipstream-php": "^2.0",
-        "opendialogai/core": "1.3.1",
+        "opendialogai/core": "dev-feature/OPNDLG-1017--transition-completing-data",
         "opendialogai/dgraph-docker": "21.03.0.2",
         "opendialogai/webchat": "1.2.0",
         "phalcongelist/php-diff": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "edac4c2c50fefeceacc631c39ed60da5",
+    "content-hash": "bccb2a543bdf34fa412fa60d192aad88",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2987,16 +2987,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "dev-feature/OPNDLG-1017--transition-completing-data",
+            "version": "1.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "e9134335f139ceabbdd935872053fd1afd00a3f3"
+                "reference": "3214f26d1769820eefdcdb52531ee75739d582c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/e9134335f139ceabbdd935872053fd1afd00a3f3",
-                "reference": "e9134335f139ceabbdd935872053fd1afd00a3f3",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/3214f26d1769820eefdcdb52531ee75739d582c4",
+                "reference": "3214f26d1769820eefdcdb52531ee75739d582c4",
                 "shasum": ""
             },
             "require": {
@@ -3024,6 +3024,7 @@
                 "phpunit/phpunit": "^9.0",
                 "squizlabs/php_codesniffer": "^3.4"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -3075,9 +3076,9 @@
             "description": "The OpenDialog Core package",
             "support": {
                 "issues": "https://github.com/opendialogai/core/issues",
-                "source": "https://github.com/opendialogai/core/tree/feature/OPNDLG-1017--transition-completing-data"
+                "source": "https://github.com/opendialogai/core/tree/1.x"
             },
-            "time": "2021-09-24T10:27:34+00:00"
+            "time": "2021-09-27T12:01:00+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "deab93c3f13a605819ceef174647a31c",
+    "content-hash": "edac4c2c50fefeceacc631c39ed60da5",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2987,16 +2987,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "1.3.1",
+            "version": "dev-feature/OPNDLG-1017--transition-completing-data",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "a285adc9cd3f711bffdd9f3ad385e3e9ffc968de"
+                "reference": "e9134335f139ceabbdd935872053fd1afd00a3f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/a285adc9cd3f711bffdd9f3ad385e3e9ffc968de",
-                "reference": "a285adc9cd3f711bffdd9f3ad385e3e9ffc968de",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/e9134335f139ceabbdd935872053fd1afd00a3f3",
+                "reference": "e9134335f139ceabbdd935872053fd1afd00a3f3",
                 "shasum": ""
             },
             "require": {
@@ -3075,9 +3075,9 @@
             "description": "The OpenDialog Core package",
             "support": {
                 "issues": "https://github.com/opendialogai/core/issues",
-                "source": "https://github.com/opendialogai/core/tree/1.3.1"
+                "source": "https://github.com/opendialogai/core/tree/feature/OPNDLG-1017--transition-completing-data"
             },
-            "time": "2021-09-21T12:31:47+00:00"
+            "time": "2021-09-24T10:27:34+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",
@@ -11560,7 +11560,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "opendialogai/core": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/tests/Feature/UIStateControllerTest.php
+++ b/tests/Feature/UIStateControllerTest.php
@@ -334,8 +334,15 @@ class UIStateControllerTest extends TestCase
         $fakeIntent2->setUpdatedAt(Carbon::parse('2021-03-12T11:57:23+0000'));
         $fakeIntent2->setTransition(new Transition($fakeConversation->getUid(), $fakeScene->getUid(), $fakeTurn->getUid()));
 
-        $intentsWithTransitions = new IntentCollection([$fakeIntent2]);
-        $fakeTurn->setResponseIntents($intentsWithTransitions);
+        $fakeIntent3 = new Intent($fakeTurn);
+        $fakeIntent3->setUid('0x9999a');
+        $fakeIntent3->setOdId('fake_intent_3');
+        $fakeIntent3->setName('fake intent 3');
+        $fakeIntent3->setCreatedAt(Carbon::parse('2021-03-12T11:57:23+0000'));
+        $fakeIntent3->setUpdatedAt(Carbon::parse('2021-03-12T11:57:23+0000'));
+        $fakeIntent3->setBehaviors(new BehaviorsCollection([new Behavior(Behavior::COMPLETING_BEHAVIOR)]));
+
+        $fakeTurn->setResponseIntents(new IntentCollection([$fakeIntent2, $fakeIntent3]));
 
         ConversationDataClient::shouldReceive('getSceneByUid')
             ->once()
@@ -349,7 +356,7 @@ class UIStateControllerTest extends TestCase
 
         TransitionDataClient::shouldReceive('getIncomingTurnTransitions')
             ->with($fakeTurn->getUid())
-            ->andReturn($intentsWithTransitions);
+            ->andReturn(new IntentCollection([$fakeIntent2]));
 
         $this->actingAs($this->user, 'api')
             ->json('GET', '/admin/api/conversation-builder/ui-state/focused/scene/' . $fakeScene->getUid())
@@ -412,6 +419,15 @@ class UIStateControllerTest extends TestCase
                                             "conversation" => "0x0002",
                                             "scene" => "0x0003",
                                             "turn" => "0x0003",
+                                        ]
+                                    ]
+                                ],
+                                "completing_intents" => [
+                                    [
+                                        "id" => "0x9999a",
+                                        "od_id" => "fake_intent_3",
+                                        "behaviors" => [
+                                            Behavior::COMPLETING_BEHAVIOR,
                                         ]
                                     ]
                                 ],

--- a/tests/Feature/UIStateControllerTest.php
+++ b/tests/Feature/UIStateControllerTest.php
@@ -323,6 +323,7 @@ class UIStateControllerTest extends TestCase
         $fakeIntent->setName('fake intent 1');
         $fakeIntent->setCreatedAt(Carbon::parse('2021-03-12T11:57:23+0000'));
         $fakeIntent->setUpdatedAt(Carbon::parse('2021-03-12T11:57:23+0000'));
+        $fakeIntent->setTransition(new Transition('0x567', null, null));
         $fakeTurn->setRequestIntents(new IntentCollection([$fakeIntent]));
 
         $fakeIntent2 = new Intent($fakeTurn);
@@ -334,7 +335,7 @@ class UIStateControllerTest extends TestCase
         $fakeIntent2->setTransition(new Transition($fakeConversation->getUid(), $fakeScene->getUid(), $fakeTurn->getUid()));
 
         $intentsWithTransitions = new IntentCollection([$fakeIntent2]);
-        $fakeTurn->setRequestIntents($intentsWithTransitions);
+        $fakeTurn->setResponseIntents($intentsWithTransitions);
 
         ConversationDataClient::shouldReceive('getSceneByUid')
             ->once()
@@ -393,7 +394,27 @@ class UIStateControllerTest extends TestCase
                                             "turn" => "0x0003",
                                         ]
                                     ]
-                                ]
+                                ],
+                                "outgoing_transitions" => [
+                                    [
+                                        "id" => "0x9998",
+                                        "od_id" => "fake_intent_1",
+                                        "transition" => [
+                                            "conversation" => "0x567",
+                                            "scene" => null,
+                                            "turn" => null,
+                                        ]
+                                    ],
+                                    [
+                                        "id" => "0x9999",
+                                        "od_id" => "fake_intent_2",
+                                        "transition" => [
+                                            "conversation" => "0x0002",
+                                            "scene" => "0x0003",
+                                            "turn" => "0x0003",
+                                        ]
+                                    ]
+                                ],
                             ]
                         ]
                     ]


### PR DESCRIPTION
This PR adds meta data to the focused scenario, conversation & scene endpoints, which includes:

 - incoming transitions to the focused object's immediate children,
 - outgoing transitions to focused scene's child intents,
 - completing intents from the focused scene's child intents.

This PR is dependent on https://github.com/opendialogai/core/pull/562.

### Example

```json
{
    ...
    "focusedScene": {
        ...
        "_meta": {
            "incoming_transitions": [{
                "id": "0x7c83b",
                "od_id":"intent.core.welcome",
                "transition": {
                    "conversation":"0x7c832",
                    "scene":"0x7c833",
                    "turn":"0x7c834"
                }
            }, {
                "id": "0x7c83c",
                "od_id":"intent.core.restart",
                "transition": {
                    "conversation":"0x7c832",
                    "scene":"0x7c833",
                    "turn":"0x7c834"
                }
            }]
        }
    }
}
```