### PR TITLE
Adding list of message template IDs to scene resources

### DIFF
--- a/app/Http/Resources/SceneResource.php
+++ b/app/Http/Resources/SceneResource.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 use OpenDialogAi\Core\Conversation\Behavior;
 use OpenDialogAi\Core\Conversation\Condition;
 use OpenDialogAi\Core\Conversation\Intent;
+use OpenDialogAi\Core\Conversation\MessageTemplate;
 use OpenDialogAi\Core\Conversation\Scene;
 use OpenDialogAi\Core\Conversation\Turn;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
@@ -36,13 +37,19 @@ class SceneResource extends JsonResource
                     Intent::UID,
                     Intent::NAME,
                     Intent::SAMPLE_UTTERANCE,
-                    Intent::SPEAKER
+                    Intent::SPEAKER,
+                    Intent::MESSAGE_TEMPLATES => [
+                        MessageTemplate::UID,
+                    ],
                 ],
                 Turn::RESPONSE_INTENTS => [
                     Intent::UID,
                     Intent::NAME,
                     Intent::SAMPLE_UTTERANCE,
                     Intent::SPEAKER,
+                    Intent::MESSAGE_TEMPLATES => [
+                        MessageTemplate::UID,
+                    ],
                 ],
             ]
         ]


### PR DESCRIPTION
This PR continues the work from https://github.com/opendialogai/opendialog/pull/400 by adding message template IDs to scene resources too.