### PR TITLE
OPNDLG-1128 - update router to allow access to user pages when no scenarios are preseent

### DIFF
--- a/resources/js/router/index.js
+++ b/resources/js/router/index.js
@@ -326,13 +326,13 @@ const router = new VueRouter({
 router.beforeEach(async (to, from, next) => {
   if (store.state.hasScenarios === null) {
     await store.dispatch('fetchScenarios').then(hasScenarios => {
-      if (!hasScenarios) {
+      if (!hasScenarios && (to.path === '/admin' || to.meta.requiresScenario)) {
         next('/admin/create-new-scenario')
       }
     }).catch(err => {
       next('/admin/create-new-scenario')
     })
-  } else if (store.state.hasScenarios === false && to.path !== '/admin/create-new-scenario') {
+  } else if (store.state.hasScenarios === false && to.path !== '/admin/create-new-scenario' && to.meta.requiresScenario) {
     next('/admin/create-new-scenario')
   }
 


### PR DESCRIPTION
This PR adds additional logic to the router to allow access to pages that do not have the meta.requiresScenario property AND lack any scenarios.

Initially a design decision was made to always push such users to the create scenario screen, but we now want users to be able to access their user account pages immediately