### PR TITLE
Feature/opndlg 1114

### DIFF
--- a/app/ImportExportHelpers/ScenarioImportExportHelper.php
+++ b/app/ImportExportHelpers/ScenarioImportExportHelper.php
@@ -216,9 +216,7 @@ class ScenarioImportExportHelper extends BaseImportExportHelper
             /** @var Conversation $conversationWithPathsSubstituted */
 
             /** @var Conversation $persistedConversation */
-            $persistedConversation = $persistedScenario->getConversations()->filter(
-                fn (Conversation $conversation) => $conversation->getOdId() === $conversationWithPathsSubstituted->getOdId()
-            )->first();
+            $persistedConversation = $persistedScenario->getConversations()->getObjectsWithId($conversationWithPathsSubstituted->getOdId())->first();
 
             self::patchConversation($persistedConversation, $conversationWithPathsSubstituted);
         }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "laravel/tinker": "^2.6",
         "laravel/ui": "^3.2",
         "maennchen/zipstream-php": "^2.0",
-        "opendialogai/core": "1.6.2",
+        "opendialogai/core": "dev-feature/OPNDLG-1114_template_performance",
         "opendialogai/dgraph-docker": "21.03.0.2",
         "opendialogai/webchat": "1.5.0",
         "phalcongelist/php-diff": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c7d2fd37caf33f0383e57e54583bb33f",
+    "content-hash": "e1aca27f8ee65a370dea6af8bfdecee3",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3335,16 +3335,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "1.6.2",
+            "version": "dev-feature/OPNDLG-1114_template_performance",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "1ebb0af91d78cb921e693e50107a85a3f508c4af"
+                "reference": "b4d1049ed660837ebf3bec2168d2754ba912a6f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/1ebb0af91d78cb921e693e50107a85a3f508c4af",
-                "reference": "1ebb0af91d78cb921e693e50107a85a3f508c4af",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/b4d1049ed660837ebf3bec2168d2754ba912a6f7",
+                "reference": "b4d1049ed660837ebf3bec2168d2754ba912a6f7",
                 "shasum": ""
             },
             "require": {
@@ -3425,9 +3425,9 @@
             "description": "The OpenDialog Core package",
             "support": {
                 "issues": "https://github.com/opendialogai/core/issues",
-                "source": "https://github.com/opendialogai/core/tree/1.6.2"
+                "source": "https://github.com/opendialogai/core/tree/feature/OPNDLG-1114_template_performance"
             },
-            "time": "2021-10-27T14:01:45+00:00"
+            "time": "2021-11-01T16:35:07+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",
@@ -12114,7 +12114,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "opendialogai/core": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -3339,12 +3339,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "9f35b4d0bae2c50bdd042246e6e20078024c4063"
+                "reference": "0a7eb0df5bda16a058734c36e48e9eb0add9dafc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/9f35b4d0bae2c50bdd042246e6e20078024c4063",
-                "reference": "9f35b4d0bae2c50bdd042246e6e20078024c4063",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/0a7eb0df5bda16a058734c36e48e9eb0add9dafc",
+                "reference": "0a7eb0df5bda16a058734c36e48e9eb0add9dafc",
                 "shasum": ""
             },
             "require": {
@@ -3427,7 +3427,7 @@
                 "issues": "https://github.com/opendialogai/core/issues",
                 "source": "https://github.com/opendialogai/core/tree/feature/OPNDLG-1114_template_performance"
             },
-            "time": "2021-11-02T09:28:14+00:00"
+            "time": "2021-11-02T13:50:49+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/composer.lock
+++ b/composer.lock
@@ -3339,12 +3339,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "0a7eb0df5bda16a058734c36e48e9eb0add9dafc"
+                "reference": "ac60473fd71a7b69cf54c47f4ccb617176611ba2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/0a7eb0df5bda16a058734c36e48e9eb0add9dafc",
-                "reference": "0a7eb0df5bda16a058734c36e48e9eb0add9dafc",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/ac60473fd71a7b69cf54c47f4ccb617176611ba2",
+                "reference": "ac60473fd71a7b69cf54c47f4ccb617176611ba2",
                 "shasum": ""
             },
             "require": {
@@ -3427,7 +3427,7 @@
                 "issues": "https://github.com/opendialogai/core/issues",
                 "source": "https://github.com/opendialogai/core/tree/feature/OPNDLG-1114_template_performance"
             },
-            "time": "2021-11-02T13:50:49+00:00"
+            "time": "2021-11-02T14:56:52+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/composer.lock
+++ b/composer.lock
@@ -3339,12 +3339,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "b4d1049ed660837ebf3bec2168d2754ba912a6f7"
+                "reference": "9f35b4d0bae2c50bdd042246e6e20078024c4063"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/b4d1049ed660837ebf3bec2168d2754ba912a6f7",
-                "reference": "b4d1049ed660837ebf3bec2168d2754ba912a6f7",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/9f35b4d0bae2c50bdd042246e6e20078024c4063",
+                "reference": "9f35b4d0bae2c50bdd042246e6e20078024c4063",
                 "shasum": ""
             },
             "require": {
@@ -3427,7 +3427,7 @@
                 "issues": "https://github.com/opendialogai/core/issues",
                 "source": "https://github.com/opendialogai/core/tree/feature/OPNDLG-1114_template_performance"
             },
-            "time": "2021-11-01T16:35:07+00:00"
+            "time": "2021-11-02T09:28:14+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",


### PR DESCRIPTION
This PR updates the ScenarioImportExport helper to avoid using the index of the sub conversation items for objects with substituted paths, and instead fetches matching objects (other than intents) by od_id. There is a new method for matching intents.