### PR TITLE
OPNDLG-1111 Hide Bot user

### DIFF
--- a/app/Http/Controllers/API/UsersController.php
+++ b/app/Http/Controllers/API/UsersController.php
@@ -28,13 +28,14 @@ class UsersController extends Controller
     /**
      * Display a listing of the resource.
      *
+     * @param Request $request
      * @return UserCollection
      */
-    public function index(): UserCollection
+    public function index(Request $request): UserCollection
     {
-        return new UserCollection(User::paginate(50));
+        $perPage = $request->get('perPage') ?? 50;
+        return new UserCollection(User::withoutBotUser()->paginate($perPage));
     }
-
 
     /**
      * Store a newly created resource in storage.

--- a/app/User.php
+++ b/app/User.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Fortify\TwoFactorAuthenticatable;
@@ -57,5 +58,10 @@ class User extends Authenticatable
     public function twoFactorAuthEnabled()
     {
         return !is_null($this->two_factor_secret);
+    }
+
+    public function scopeWithoutBotUser(Builder $query)
+    {
+        return $query->where('email', '<>', config('sanctum.bot_user'));
     }
 }

--- a/tests/Feature/UsersTest.php
+++ b/tests/Feature/UsersTest.php
@@ -67,6 +67,24 @@ class UsersTest extends TestCase
         $this->assertEquals(count($response->data), 3);
     }
 
+    public function testHideBotUser()
+    {
+        $response = $this->actingAs($this->user, 'api')
+            ->json('GET', '/admin/api/user?perPage=100')
+            ->getData();
+
+        $this->assertEquals(53, count($response->data));
+
+        // Set the first user to be the bot user, now it should no longer be returned
+        $this->app['config']->set('sanctum.bot_user', User::first()->email);
+
+        $response = $this->actingAs($this->user, 'api')
+            ->json('GET', '/admin/api/user?perPage=100')
+            ->getData();
+
+        $this->assertEquals(52, count($response->data));
+    }
+
     public function testUsersUpdateEndpoint()
     {
         $user = User::latest()->first();


### PR DESCRIPTION
This PR hides the sanctum bot user from the main user list API if one is set.
It adds a new scope method to get users without the bot user to the User model.

It also updates the /users route to accept a `'perPage` query param to select how many users to return per page