### PR TITLE
Duplicate destination

### DIFF
--- a/app/Http/Controllers/API/IntentsController.php
+++ b/app/Http/Controllers/API/IntentsController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers\API;
 use App\Http\Controllers\Controller;
 use App\Http\Facades\Serializer;
 use App\Http\Requests\ConversationObjectDuplicationRequest;
+use App\Http\Requests\IntentDuplicationRequest;
 use App\Http\Requests\IntentRequest;
 use App\Http\Resources\ScenarioIntentCollection;
 use App\Http\Resources\IntentResource;
@@ -71,14 +72,19 @@ class IntentsController extends Controller
      * @param Intent $intent
      * @return IntentResource
      */
-    public function duplicate(ConversationObjectDuplicationRequest $request, Intent $intent): IntentResource
+    public function duplicate(IntentDuplicationRequest $request, Intent $intent): IntentResource
     {
         $isRequest = $intent->isRequestIntent();
         $intent = IntentDataClient::getFullIntentGraph($intent->getUid());
 
-        if ($intent->getSpeaker() === Intent::APP) {
+        if ($turnUid = $request->get('destination')) {
+            $turn = ConversationDataClient::getTurnByUid($turnUid);
+            $intent->setTurn($turn);
+        } else {
             $turn = ConversationDataClient::getTurnByUid($intent->getTurn()->getUid());
+        }
 
+        if ($intent->getSpeaker() === Intent::APP) {
             /** @var Intent $intent */
             $intent = $request->setUniqueOdId($intent, $request, $turn, true);
         }

--- a/app/Http/Requests/IntentDuplicationRequest.php
+++ b/app/Http/Requests/IntentDuplicationRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Rules\TurnExists;
+
+class IntentDuplicationRequest extends ConversationObjectDuplicationRequest
+{
+    use ConversationObjectRequestTrait;
+
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    protected function prepareForValidation()
+    {
+        $this->merge(['destination' => $this->get('destination')]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return parent::rules() + ['destination' => [new TurnExists]];
+    }
+}

--- a/app/Http/Requests/IntentDuplicationRequest.php
+++ b/app/Http/Requests/IntentDuplicationRequest.php
@@ -30,6 +30,6 @@ class IntentDuplicationRequest extends ConversationObjectDuplicationRequest
      */
     public function rules()
     {
-        return parent::rules() + ['destination' => [new TurnExists]];
+        return parent::rules() + ['destination' => ['nullable', new TurnExists]];
     }
 }

--- a/app/Rules/TurnExists.php
+++ b/app/Rules/TurnExists.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use OpenDialogAi\Core\Conversation\Exceptions\ConversationObjectNotFoundException;
+use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
+
+class TurnExists implements Rule
+{
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  string  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        try {
+            ConversationDataClient::getTurnByUid($value);
+            return true;
+        } catch (ConversationObjectNotFoundException $exception) {
+            return false;
+        }
+    }
+
+    public function message()
+    {
+        return 'The provided turn does not exist.';
+    }
+}

--- a/tests/Feature/IntentsTest.php
+++ b/tests/Feature/IntentsTest.php
@@ -135,8 +135,8 @@ class IntentsTest extends TestCase
                     "transition" => [],
                     "virtual_intent" => [],
                     "sample_utterance" => "Welcome user!"
-    ],
-]]);
+                ],
+            ]]);
     }
 
     public function testAddRequestIntentToTurn()
@@ -351,7 +351,7 @@ class IntentsTest extends TestCase
 
         $this->actingAs($this->user, 'api')
             ->json('GET', '/admin/api/conversation-builder/turns/' . $fakeTurn->getUid() . '/turn-intents/' .
-$fakeRequestIntent->getUid())
+                $fakeRequestIntent->getUid())
             //            ->assertStatus(200)
             ->assertJson([
                 'order' => 'REQUEST',
@@ -419,17 +419,17 @@ $fakeRequestIntent->getUid())
         $this->actingAs($this->user, 'api')
             ->json('PATCH', '/admin/api/conversation-builder/turns/' . $fakeTurn->getUid() . '/turn-intents/' .
                 $fakeRequestIntent->getUid(), [
-                    'order' => 'RESPONSE',
-                    'intent' => [
-                        'name' => $fakeUpdatedResponseIntent->getName(),
-                        'id' => $fakeUpdatedResponseIntent->getUid(),
-                        'od_id' => $fakeUpdatedResponseIntent->getOdId(),
-                        'description' =>  $fakeUpdatedResponseIntent->getDescription(),
-                        'confidence' =>  $fakeUpdatedResponseIntent->getConfidence(),
-                        'speaker' =>  $fakeUpdatedResponseIntent->getSpeaker(),
-                        'listens_for' => $fakeUpdatedResponseIntent->getListensFor(),
-                        'sample_utterance' => $fakeUpdatedResponseIntent->getSampleUtterance()
-                    ]
+                'order' => 'RESPONSE',
+                'intent' => [
+                    'name' => $fakeUpdatedResponseIntent->getName(),
+                    'id' => $fakeUpdatedResponseIntent->getUid(),
+                    'od_id' => $fakeUpdatedResponseIntent->getOdId(),
+                    'description' => $fakeUpdatedResponseIntent->getDescription(),
+                    'confidence' => $fakeUpdatedResponseIntent->getConfidence(),
+                    'speaker' => $fakeUpdatedResponseIntent->getSpeaker(),
+                    'listens_for' => $fakeUpdatedResponseIntent->getListensFor(),
+                    'sample_utterance' => $fakeUpdatedResponseIntent->getSampleUtterance()
+                ]
             ])
             ->assertJson([
                 'order' => 'RESPONSE',
@@ -549,9 +549,9 @@ $fakeRequestIntent->getUid())
                 'name' => $fakeIntentUpdated->getName(),
                 'id' => $fakeIntentUpdated->getUid(),
                 'od_id' => $fakeIntentUpdated->getOdId(),
-                'description' =>  $fakeIntentUpdated->getDescription(),
-                'confidence' =>  $fakeIntentUpdated->getConfidence(),
-                'speaker' =>  $fakeIntentUpdated->getSpeaker(),
+                'description' => $fakeIntentUpdated->getDescription(),
+                'confidence' => $fakeIntentUpdated->getConfidence(),
+                'speaker' => $fakeIntentUpdated->getSpeaker(),
                 'listens_for' => $fakeIntentUpdated->getListensFor(),
                 'sample_utterance' => $fakeIntentUpdated->getSampleUtterance()
             ])
@@ -652,7 +652,7 @@ $fakeRequestIntent->getUid())
             ->assertJson([
                 'name' => 'Example Request Intent',
                 'od_id' => 'intent.app.exampleRequestIntent',
-                'id'=> '0x9999',
+                'id' => '0x9999',
             ]);
     }
 
@@ -680,7 +680,9 @@ $fakeRequestIntent->getUid())
         // Called in the controller, getting parent & sibling data
         ConversationDataClient::shouldReceive('getTurnByUid')
             ->once()
-            ->andReturnUsing(function ($uid) use ($turn) { return $turn; });
+            ->andReturnUsing(function ($uid) use ($turn) {
+                return $turn;
+            });
 
         // Called in controller, once before persisting and again after
         IntentDataClient::shouldReceive('getFullIntentGraph')
@@ -704,7 +706,97 @@ $fakeRequestIntent->getUid())
             ->assertJson([
                 'name' => 'Example Response IntentCopy',
                 'od_id' => 'intent.app.exampleResponseIntentCopy',
-                'id'=> '0x9999',
+                'id' => '0x9999',
             ]);
+    }
+
+    public function testDuplicationDestinationDoesNotExist()
+    {
+        $scenario = ScenariosTest::getFakeScenarioForDuplication();
+
+        /** @var Conversation $conversation */
+        $conversation = $scenario->getConversations()->getObjectsWithId('example_conversation')->first();
+
+        /** @var Scene $scene */
+        $scene = $conversation->getScenes()->getObjectsWithId('example_scene')->first();
+
+        /** @var Turn $turn */
+        $turn = $scene->getTurns()->getObjectsWithId('example_turn')->first();
+
+        /** @var Intent $intent */
+        $intent = $turn->getResponseIntents()->getObjectsWithId('intent.app.exampleResponseIntent')->first();
+
+        // Called during route binding
+        ConversationDataClient::shouldReceive('getIntentByUid')
+            ->once()
+            ->andReturn($intent);
+
+        // Called in the request object to validate the turn exists
+        ConversationDataClient::shouldReceive('getTurnByUid')
+            ->once()
+            ->withAnyArgs()
+            ->andThrow(new ConversationObjectNotFoundException());
+
+        $this->actingAs($this->user, 'api')
+            ->json('POST', '/admin/api/conversation-builder/intents/' . $intent->getUid() . '/duplicate?destination=' . $turn->getUid())
+            ->assertStatus(422);
+    }
+
+    public function testDuplicationDestinationValid()
+    {
+        $scenario = ScenariosTest::getFakeScenarioForDuplication();
+
+        /** @var Conversation $conversation */
+        $conversation = $scenario->getConversations()->getObjectsWithId('example_conversation')->first();
+
+        /** @var Scene $scene */
+        $scene = $conversation->getScenes()->getObjectsWithId('example_scene')->first();
+
+        /** @var Turn $turn */
+        $turn = $scene->getTurns()->getObjectsWithId('example_turn')->first();
+
+        $destinationTurn = $scene->getTurns()->getObjectsWithId('example_turn_copy')->first();
+
+        /** @var Intent $intent */
+        $intent = $turn->getResponseIntents()->getObjectsWithId('intent.app.exampleResponseIntent')->first();
+
+        // Called during route binding
+        ConversationDataClient::shouldReceive('getIntentByUid')
+            ->once()
+            ->andReturn($intent);
+
+        // Called in the controller and in the request class
+        ConversationDataClient::shouldReceive('getTurnByUid')
+            ->twice()
+            ->withArgs([$destinationTurn->getUid()])
+            ->andReturnUsing(function ($uid) use ($turn) {
+                return $turn;
+            });
+
+        // Called in controller, once before persisting and again after
+        IntentDataClient::shouldReceive('getFullIntentGraph')
+            ->twice()
+            ->andReturnUsing(function ($uid) use ($intent) {
+                $intent->setUid($uid);
+                return $intent;
+            });
+
+        IntentDataClient::shouldReceive('addFullIntentGraph')
+            ->once()
+            ->andReturnUsing(function ($intent) {
+                $intent->setUid('0x9999');
+                return $intent;
+            });
+
+        // The OD ID should be the same because it is used for interpretation purposes and is therefore not expected to be unique
+        $this->actingAs($this->user, 'api')
+            ->json('POST', '/admin/api/conversation-builder/intents/' . $intent->getUid() . '/duplicate?destination=' . $destinationTurn->getUid())
+            ->assertStatus(200)
+            ->assertJson([
+                'name' => 'Example Response IntentCopy',
+                'od_id' => 'intent.app.exampleResponseIntentCopy',
+                'id' => '0x9999',
+            ]);
+
     }
 }

--- a/tests/Feature/IntentsTest.php
+++ b/tests/Feature/IntentsTest.php
@@ -645,6 +645,13 @@ class IntentsTest extends TestCase
                 return $intent;
             });
 
+        // Called in the controller, getting parent & sibling data
+        ConversationDataClient::shouldReceive('getTurnByUid')
+            ->once()
+            ->andReturnUsing(function ($uid) use ($turn) {
+                return $turn;
+            });
+
         // The OD ID should be the same because it is used for interpretation purposes and is therefore not expected to be unique
         $this->actingAs($this->user, 'api')
             ->json('POST', '/admin/api/conversation-builder/intents/' . $intent->getUid() . '/duplicate')


### PR DESCRIPTION
This PR updates the intent duplicate endpoint to also accept an optional `destination` query param that decides where the new intent should be duplicated to.

The destination should be a valid Turn UID.

As part of the update, a new IntentDuplicate request has been created that extends the standard Conversation Object Duplication request by adding the `destination` field and ensuring it is a valid Turn UID that has been passed.