### PR TITLE
Message XML validation

### DIFF
--- a/app/Http/Requests/MessageTemplateRequest.php
+++ b/app/Http/Requests/MessageTemplateRequest.php
@@ -3,8 +3,16 @@
 
 namespace App\Http\Requests;
 
+use Exception;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use OpenDialogAi\Core\Components\Configuration\ComponentConfiguration;
+use OpenDialogAi\Core\Conversation\Facades\ConversationDataClient;
+use OpenDialogAi\Core\Conversation\Intent;
+use OpenDialogAi\PlatformEngine\Components\BasePlatform;
+use OpenDialogAi\PlatformEngine\Components\WebchatPlatform;
+use OpenDialogAi\PlatformEngine\Services\PlatformComponentServiceInterface;
+use OpenDialogAi\ResponseEngine\Formatters\MessageFormatterInterface;
 use OpenDialogAi\ResponseEngine\Rules\MessageXML;
 
 class MessageTemplateRequest extends FormRequest
@@ -27,6 +35,8 @@ class MessageTemplateRequest extends FormRequest
      */
     public function rules()
     {
+        $messageXmlRule = $this->getMessageXmlRule();
+
         return [
             'id' => 'string',
             'od_id' => 'string',
@@ -36,8 +46,42 @@ class MessageTemplateRequest extends FormRequest
             'conditions' => 'array',
             'message_markup' => [
                 Rule::requiredIf($this->method() === 'POST'),
-                new MessageXML()
+                $messageXmlRule,
             ]
         ];
+    }
+
+    /**
+     * @return MessageXML
+     */
+    private function getMessageXmlRule(): MessageXML
+    {
+        /** @var Intent $intent */
+        $intent = $this->route('intent');
+
+        $intent = ConversationDataClient::getScenarioWithFocusedIntent($intent->getUid());
+
+        /** @var ComponentConfiguration $configuration */
+        $configuration = ComponentConfiguration::byScenario($intent->getScenario()->getUid())
+            ->platforms()
+            ->first();
+
+        if ($configuration) {
+            $componentId = $configuration->component_id;
+        } else {
+            $componentId = WebchatPlatform::getComponentId();
+        }
+
+        /** @var class-string<BasePlatform> $componentClass */
+        try {
+            $componentClass = resolve(PlatformComponentServiceInterface::class)->get($componentId);
+        } catch (Exception $e) {
+            $componentClass = WebchatPlatform::class;
+        }
+
+        /** @var class-string<MessageFormatterInterface> $componentClass */
+        $formatterClass = $componentClass::getFormatterClass();
+
+        return $formatterClass::getMessageXmlRule();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "laravel/tinker": "^2.6",
         "laravel/ui": "^3.2",
         "maennchen/zipstream-php": "^2.0",
-        "opendialogai/core": "1.x-dev",
+        "opendialogai/core": "dev-fix/OPNDLG-1321--message-validation",
         "opendialogai/dgraph-docker": "21.03.0.2",
         "opendialogai/webchat": "1.5.0",
         "phalcongelist/php-diff": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "laravel/tinker": "^2.6",
         "laravel/ui": "^3.2",
         "maennchen/zipstream-php": "^2.0",
-        "opendialogai/core": "dev-fix/OPNDLG-1321--message-validation",
+        "opendialogai/core": "1.7.0",
         "opendialogai/dgraph-docker": "21.03.0.2",
         "opendialogai/webchat": "1.5.0",
         "phalcongelist/php-diff": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "564e0db1758d8fd5b75ed7caa1c85567",
+    "content-hash": "4163b1586527c8dce50b961c204d01c2",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3335,16 +3335,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "dev-fix/OPNDLG-1321--message-validation",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "4fcda9c1fe345bf616b012624d32d8d457c3782f"
+                "reference": "6af4389565593a23c18a7c1b110f993713c39ac4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/4fcda9c1fe345bf616b012624d32d8d457c3782f",
-                "reference": "4fcda9c1fe345bf616b012624d32d8d457c3782f",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/6af4389565593a23c18a7c1b110f993713c39ac4",
+                "reference": "6af4389565593a23c18a7c1b110f993713c39ac4",
                 "shasum": ""
             },
             "require": {
@@ -3425,9 +3425,9 @@
             "description": "The OpenDialog Core package",
             "support": {
                 "issues": "https://github.com/opendialogai/core/issues",
-                "source": "https://github.com/opendialogai/core/tree/fix/OPNDLG-1321--message-validation"
+                "source": "https://github.com/opendialogai/core/tree/1.7.0"
             },
-            "time": "2021-12-20T17:43:26+00:00"
+            "time": "2021-12-21T14:17:04+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",
@@ -12055,9 +12055,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "opendialogai/core": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -12066,5 +12064,5 @@
         "ext-simplexml": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "990b9296b8bdca625d5a899203bd8714",
+    "content-hash": "564e0db1758d8fd5b75ed7caa1c85567",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3335,16 +3335,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "1.x-dev",
+            "version": "dev-fix/OPNDLG-1321--message-validation",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "55b86b31975175e44e84b5cce6afe06e4040a6cb"
+                "reference": "4fcda9c1fe345bf616b012624d32d8d457c3782f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/55b86b31975175e44e84b5cce6afe06e4040a6cb",
-                "reference": "55b86b31975175e44e84b5cce6afe06e4040a6cb",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/4fcda9c1fe345bf616b012624d32d8d457c3782f",
+                "reference": "4fcda9c1fe345bf616b012624d32d8d457c3782f",
                 "shasum": ""
             },
             "require": {
@@ -3374,7 +3374,6 @@
                 "phpunit/phpunit": "^9.0",
                 "squizlabs/php_codesniffer": "^3.4"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -3426,9 +3425,9 @@
             "description": "The OpenDialog Core package",
             "support": {
                 "issues": "https://github.com/opendialogai/core/issues",
-                "source": "https://github.com/opendialogai/core/tree/1.x"
+                "source": "https://github.com/opendialogai/core/tree/fix/OPNDLG-1321--message-validation"
             },
-            "time": "2021-12-20T13:44:23+00:00"
+            "time": "2021-12-20T17:43:26+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",


### PR DESCRIPTION
This PR is dependent on https://github.com/opendialogai/core/pull/584, and #431 (as the related core PR had already been merged, causing test failures). This PR ensures that during message editing, the message markup validation rule associated with the intent's scenario is used to validate the XML. By default the Webchat XML validation will be used.