### PR TITLE
OPNDLG-1164 - rename WebchatDemo component in router

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@coreui/coreui": "^2.1.12",
         "@coreui/icons": "^0.3.0",
         "@coreui/vue": "^2.1.2",
-        "@opendialogai/opendialog-design-system-pkg": "1.6.8-2",
+        "@opendialogai/opendialog-design-system-pkg": "1.6.8",
         "babel-runtime": "^6.26.0",
         "bootstrap-vue": "^2.21.2",
         "core-js": "^3.1.4",

--- a/resources/js/router/index.js
+++ b/resources/js/router/index.js
@@ -13,7 +13,7 @@ import UserView from '@opendialogai/opendialog-design-system-pkg/src/components/
 import RequestView from '@opendialogai/opendialog-design-system-pkg/src/components/Views/RequestView'
 import GlobalContextView from '@opendialogai/opendialog-design-system-pkg/src/components/Views/GlobalContextView'
 import WarningView from '@opendialogai/opendialog-design-system-pkg/src/components/Views/WarningView'
-import WebchatDemo from '@opendialogai/opendialog-design-system-pkg/src/components/Views/WebchatDemo'
+import Preview from '@opendialogai/opendialog-design-system-pkg/src/components/Views/Preview'
 import ConversationLog from '@opendialogai/opendialog-design-system-pkg/src/components/Views/ConversationLog'
 import DynamicAttribute from '@/views/DynamicAttribute'
 import Scenarios
@@ -322,8 +322,8 @@ const router = new VueRouter({
         },
         {
           path: 'demo',
-          name: 'webchat-demo',
-          component: WebchatDemo,
+          name: 'preview',
+          component: Preview,
           meta: {
             title: 'Preview',
             requiresScenario: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -841,10 +841,10 @@
   dependencies:
     "@octokit/openapi-types" "^11.2.0"
 
-"@opendialogai/opendialog-design-system-pkg@1.6.8-2":
-  version "1.6.8-2"
-  resolved "https://registry.yarnpkg.com/@opendialogai/opendialog-design-system-pkg/-/opendialog-design-system-pkg-1.6.8-2.tgz#b47172fc797311b61aa6a7e0cf0dc912dd65e6dd"
-  integrity sha512-iTWMpk6EhKqvYc6hZ72nvh477346XK/NeGL8P3rtHwas8CfLMHAtLSWht4lsNanzDkoPlI5aEvLzsNSveyv3kQ==
+"@opendialogai/opendialog-design-system-pkg@1.6.8":
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/@opendialogai/opendialog-design-system-pkg/-/opendialog-design-system-pkg-1.6.8.tgz#c13fbbeacaf33a3fdd88bd4aae78023af15f2def"
+  integrity sha512-UJ4LuPpxwY8IGMRM2SxI7ItZ/TKAelBlUFqBLxI4XpVaaKD7PS0bSHHPR6ztEU/C9l4vVouYetJRl3bVplhKLw==
   dependencies:
     "@coreui/coreui" "^2.1.12"
     "@coreui/coreui-plugin-chartjs-custom-tooltips" "^1.3.1"


### PR DESCRIPTION
This PR renames the WebchatDemo component so that it's no longer webchat specific