### PR TITLE
Fix Intent ordering

### DIFF
--- a/app/Http/Controllers/API/IntentsController.php
+++ b/app/Http/Controllers/API/IntentsController.php
@@ -90,6 +90,12 @@ class IntentsController extends Controller
             $intent = $request->setUniqueOdId($intent, $request, $turn, true);
         }
 
+        if ($isRequest) {
+            $intent->setOrder(count($turn->getRequestIntents()));
+        } else {
+            $intent->setOrder(count($turn->getResponseIntents()));
+        }
+
         $intent->removeUid();
 
         $duplicate = IntentDataClient::addFullIntentGraph($intent, $isRequest);

--- a/app/Http/Controllers/API/MessageTemplateController.php
+++ b/app/Http/Controllers/API/MessageTemplateController.php
@@ -28,6 +28,7 @@ class MessageTemplateController extends Controller
         /** @var MessageTemplate $newMessageTemplate */
         $newMessageTemplate = Serializer::deserialize($request->getContent(), MessageTemplate::class, 'json');
         $newMessageTemplate->setIntent($intent);
+        $newMessageTemplate->setOrder(count($intent->getMessageTemplates()));
 
         $messageTemplate = $this->messageTemplateDataClient->addMessageTemplateToIntent($newMessageTemplate);
 

--- a/app/Http/Controllers/API/TurnsController.php
+++ b/app/Http/Controllers/API/TurnsController.php
@@ -73,12 +73,15 @@ class TurnsController extends Controller
      */
     public function storeTurnIntentAgainstTurn(Turn $turn, TurnIntentRequest $request): TurnIntentResource
     {
+        /** @var Intent $newIntent */
         $newIntent = Serializer::denormalize($request->get('intent'), Intent::class, 'json');
         $newIntent->setTurn($turn);
 
         if ($request->get('order') === 'REQUEST') {
+            $newIntent->setOrder(count($turn->getRequestIntents()));
             $savedIntent = ConversationDataClient::addRequestIntent($newIntent);
         } else {
+            $newIntent->setOrder(count($turn->getResponseIntents()));
             $savedIntent = ConversationDataClient::addResponseIntent($newIntent);
         }
 
@@ -204,6 +207,7 @@ class TurnsController extends Controller
             $messageTemplate->setMessageMarkup(
                 (new MessageMarkUpGenerator())->addTextMessage($intent->getSampleUtterance())->getMarkUp()
             );
+            $messageTemplate->setOrder(0);
 
             MessageTemplateDataClient::addMessageTemplateToIntent($messageTemplate);
         } else {

--- a/app/Http/Requests/IntentRequest.php
+++ b/app/Http/Requests/IntentRequest.php
@@ -57,8 +57,7 @@ class IntentRequest extends FormRequest
                 'string',
             ],
             "${prefix}actions" => 'array',
-            "${prefix}training_phrases" => 'array',
-            "${prefix}order" => 'int',
+            "${prefix}training_phrases" => 'array'
         ];
     }
 

--- a/app/Http/Requests/IntentRequest.php
+++ b/app/Http/Requests/IntentRequest.php
@@ -58,6 +58,7 @@ class IntentRequest extends FormRequest
             ],
             "${prefix}actions" => 'array',
             "${prefix}training_phrases" => 'array',
+            "${prefix}order" => 'int',
         ];
     }
 

--- a/app/Http/Resources/FocusedIntentResource.php
+++ b/app/Http/Resources/FocusedIntentResource.php
@@ -58,7 +58,9 @@ class FocusedIntentResource extends JsonResource
                     Condition::OPERATION_ATTRIBUTES,
                     Condition::PARAMETERS
                 ],
+                MessageTemplate::ORDER,
             ],
+            Intent::ORDER,
             Intent::TURN => [
                 Turn::UID,
                 Turn::OD_ID,
@@ -95,7 +97,9 @@ class FocusedIntentResource extends JsonResource
                             Condition::OPERATION_ATTRIBUTES,
                             Condition::PARAMETERS
                         ],
+                        MessageTemplate::ORDER,
                     ],
+                    Intent::ORDER,
                     Intent::ACTIONS => Action::FIELDS
                 ],
                 Turn::RESPONSE_INTENTS =>[
@@ -128,9 +132,12 @@ class FocusedIntentResource extends JsonResource
                             Condition::OPERATION_ATTRIBUTES,
                             Condition::PARAMETERS
                         ],
+                        MessageTemplate::ORDER,
                     ],
+                    Intent::ORDER,
                     Intent::ACTIONS => Action::FIELDS
                 ],
+                Intent::ORDER,
                 Turn::SCENE => [
                     Scene::UID,
                     Scene::OD_ID,

--- a/app/Http/Resources/MessageTemplateResource.php
+++ b/app/Http/Resources/MessageTemplateResource.php
@@ -30,6 +30,7 @@ class MessageTemplateResource extends JsonResource
             MessageTemplate::UPDATED_AT,
             MessageTemplate::BEHAVIORS => Behavior::FIELDS,
             MessageTemplate::CONDITIONS => Condition::FIELDS,
+            MessageTemplate::ORDER,
             MessageTemplate::INTENT => [
                 Intent::UID,
                 Intent::OD_ID,

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "laravel/tinker": "^2.6",
         "laravel/ui": "^3.2",
         "maennchen/zipstream-php": "^2.0",
-        "opendialogai/core": "1.x-dev",
+        "opendialogai/core": "dev-feature/OPNDLG-1362_fix_intents_order",
         "opendialogai/dgraph-docker": "21.03.0.2",
         "opendialogai/webchat": "1.x-dev",
         "phalcongelist/php-diff": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e1213c1d6a8fec7869b749fa8a91a364",
+    "content-hash": "056ffc38ff1d01a109425323dfbe83e1",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3335,16 +3335,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "1.x-dev",
+            "version": "dev-feature/OPNDLG-1362_fix_intents_order",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "6c6d2951e4c7e4388db4ff3d4dd368dfb7ac972d"
+                "reference": "25e771d5eac8f296797ed4bec8dea023f2c01f29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/6c6d2951e4c7e4388db4ff3d4dd368dfb7ac972d",
-                "reference": "6c6d2951e4c7e4388db4ff3d4dd368dfb7ac972d",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/25e771d5eac8f296797ed4bec8dea023f2c01f29",
+                "reference": "25e771d5eac8f296797ed4bec8dea023f2c01f29",
                 "shasum": ""
             },
             "require": {
@@ -3375,7 +3375,6 @@
                 "phpunit/phpunit": "^9.0",
                 "squizlabs/php_codesniffer": "^3.4"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "laravel": {
@@ -3430,9 +3429,9 @@
             "description": "The OpenDialog Core package",
             "support": {
                 "issues": "https://github.com/opendialogai/core/issues",
-                "source": "https://github.com/opendialogai/core/tree/1.x"
+                "source": "https://github.com/opendialogai/core/tree/feature/OPNDLG-1362_fix_intents_order"
             },
-            "time": "2022-02-18T12:02:42+00:00"
+            "time": "2022-02-24T14:06:45+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/tests/Feature/IntentsTest.php
+++ b/tests/Feature/IntentsTest.php
@@ -210,7 +210,7 @@ class IntentsTest extends TestCase
         $fakeTurn->setName('New Example turn 1');
         $fakeTurn->setOdId('new_example_turn_1');
         $fakeTurn->setDescription("An new example turn 1");
-        $fakeTurn->setRequestIntents(new IntentCollection(
+        $fakeTurn->setResponseIntents(new IntentCollection(
             [
                 $this->createIntent($fakeTurn, '0x006', 'pre-existing1', Intent::USER),
                 $this->createIntent($fakeTurn, '0x007', 'pre-existing2', Intent::USER)

--- a/tests/Feature/MessageGraphTemplateTest.php
+++ b/tests/Feature/MessageGraphTemplateTest.php
@@ -147,7 +147,11 @@ class MessageGraphTemplateTest extends TestCase
 
         MessageTemplateDataClient::shouldReceive('addMessageTemplateToIntent')
             ->once()
-            ->withAnyArgs()
+            ->with(
+                \Mockery::on(function ($message) {
+                    return $message->getOrder() === 0; // the first message against the intent
+                }),
+            )
             ->andReturn($createdMessageTemplate);
 
         $this->actingAs($this->user, 'api')

--- a/tests/Feature/ScenariosTest.php
+++ b/tests/Feature/ScenariosTest.php
@@ -711,6 +711,11 @@ class ScenariosTest extends TestCase
 
         $duplicated = null;
         ScenarioDataClient::shouldReceive('addFullScenarioGraph')
+            ->with(
+                \Mockery::on(function ($scenario) {
+
+                })
+            )
             ->once()
             ->andReturnUsing(function ($scenario) use (&$duplicated) {
                 $scenario = $scenario->copy();

--- a/tests/Feature/ScenariosTest.php
+++ b/tests/Feature/ScenariosTest.php
@@ -711,11 +711,6 @@ class ScenariosTest extends TestCase
 
         $duplicated = null;
         ScenarioDataClient::shouldReceive('addFullScenarioGraph')
-            ->with(
-                \Mockery::on(function ($scenario) {
-
-                })
-            )
             ->once()
             ->andReturnUsing(function ($scenario) use (&$duplicated) {
                 $scenario = $scenario->copy();


### PR DESCRIPTION
This a draft PR for testing before being finalised.

It updates the creation and duplication of intents and messages to set an order field based on the current number of intents and message templates.

The goal is to maintain order when importing or duplicating a scenario.

The logic in the setTimestamps method in the associated core method will take into account the current order an intent or message has, or set one based on an ongoing count 