### PR TITLE
Update Message Template Dialogflow messages

### DIFF
--- a/app/Console/Commands/UpdateDialogflowMessage.php
+++ b/app/Console/Commands/UpdateDialogflowMessage.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use OpenDialogAi\Core\Conversation\Facades\MessageTemplateDataClient;
+use OpenDialogAi\Core\Conversation\MessageTemplate;
+
+class UpdateDialogflowMessage extends Command
+{
+    const REGEX = '/{[[:space:]]*user.dialogflow_message[[:space:]]*}/';
+
+    protected $signature = 'attribute_message:update';
+
+    protected $description = "Updates any messages that directly use user.dialogflow_message in a message template and replaces 
+    with an attribute message";
+
+    public function handle()
+    {
+        $messageTemplates = MessageTemplateDataClient::getAllMessageTemplates();
+
+        $messageTemplates->each(function (MessageTemplate $messageTemplate) {
+            $messageMarkup = $messageTemplate->getMessageMarkup();
+            if ($this->containsDialogflowMessage($messageMarkup)) {
+                $messageMarkup = $this->replaceWithAttributeMessage($messageMarkup);
+                $messageTemplate->setMessageMarkup($messageMarkup);
+                MessageTemplateDataClient::updateMessageTemplate($messageTemplate);
+                $this->info(sprintf("Updating message template with Id %s", $messageTemplate->getUid()));
+            }
+        });
+    }
+
+    /**
+     * Checks if the message mark up contains a dialogflow_message attribute from the user context in standard attribute notation
+     *
+     * @param string $messageMarkup
+     * @return bool
+     */
+    private function containsDialogflowMessage(string $messageMarkup)
+    {
+        return
+            preg_match(self::REGEX, $messageMarkup) &&
+            !Str::contains($messageMarkup, "<attribute-message>");
+    }
+
+    /**
+     * Replaces the user.dialogflow_message attribute with an attribute mesasge without the attribute curly brace notation
+     *
+     * @param $messageMarkup
+     * @return array|string|string[]|null
+     */
+    private function replaceWithAttributeMessage($messageMarkup)
+    {
+        return preg_replace(
+            self::REGEX,
+            '<attribute-message>user.dialogflow_message</attribute-message>',
+            $messageMarkup
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "laravel/tinker": "^2.6",
         "laravel/ui": "^3.2",
         "maennchen/zipstream-php": "^2.0",
-        "opendialogai/core": "1.12.1",
+        "opendialogai/core": "dev-fix/OPNDLG-798_attribute_messages",
         "opendialogai/dgraph-docker": "21.03.0.2",
         "opendialogai/webchat": "1.7.1",
         "phalcongelist/php-diff": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4b9bac0bef9420b0c80c143343535e83",
+    "content-hash": "05cc6b19042f8a4b52fb8eb243d7ef78",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3325,16 +3325,16 @@
         },
         {
             "name": "opendialogai/core",
-            "version": "1.12.1",
+            "version": "dev-fix/OPNDLG-798_attribute_messages",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "430d3b11b55a4bcbc2d01a35ba17b3875d05c014"
+                "reference": "d6e9bedd457c1f8fd200ba2c5d4234f188b6fc6e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/430d3b11b55a4bcbc2d01a35ba17b3875d05c014",
-                "reference": "430d3b11b55a4bcbc2d01a35ba17b3875d05c014",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/d6e9bedd457c1f8fd200ba2c5d4234f188b6fc6e",
+                "reference": "d6e9bedd457c1f8fd200ba2c5d4234f188b6fc6e",
                 "shasum": ""
             },
             "require": {
@@ -3419,9 +3419,9 @@
             "description": "The OpenDialog Core package",
             "support": {
                 "issues": "https://github.com/opendialogai/core/issues",
-                "source": "https://github.com/opendialogai/core/tree/1.12.1"
+                "source": "https://github.com/opendialogai/core/tree/fix/OPNDLG-798_attribute_messages"
             },
-            "time": "2022-03-11T10:47:59+00:00"
+            "time": "2022-03-24T09:01:56+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",
@@ -12061,7 +12061,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "opendialogai/core": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -3329,12 +3329,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/opendialogai/core.git",
-                "reference": "d6e9bedd457c1f8fd200ba2c5d4234f188b6fc6e"
+                "reference": "8bdd72163f1d585a643370101392c5fcb5af0a01"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opendialogai/core/zipball/d6e9bedd457c1f8fd200ba2c5d4234f188b6fc6e",
-                "reference": "d6e9bedd457c1f8fd200ba2c5d4234f188b6fc6e",
+                "url": "https://api.github.com/repos/opendialogai/core/zipball/8bdd72163f1d585a643370101392c5fcb5af0a01",
+                "reference": "8bdd72163f1d585a643370101392c5fcb5af0a01",
                 "shasum": ""
             },
             "require": {
@@ -3421,7 +3421,7 @@
                 "issues": "https://github.com/opendialogai/core/issues",
                 "source": "https://github.com/opendialogai/core/tree/fix/OPNDLG-798_attribute_messages"
             },
-            "time": "2022-03-24T09:01:56+00:00"
+            "time": "2022-03-24T09:17:27+00:00"
         },
         {
             "name": "opendialogai/dgraph-docker",

--- a/tests/Feature/UpdateDialogflowMessageCommandTest.php
+++ b/tests/Feature/UpdateDialogflowMessageCommandTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Feature;
+
+use OpenDialogAi\Core\Conversation\Facades\MessageTemplateDataClient;
+use OpenDialogAi\Core\Conversation\MessageTemplate;
+use OpenDialogAi\Core\Conversation\MessageTemplateCollection;
+use Tests\TestCase;
+
+class UpdateDialogflowMessageCommandTest extends TestCase
+{
+    public function testUpdateNoValidMessagesMessages()
+    {
+        $markupOne = "<message><attribute-message>user.dialogflow_message</attribute-message></message>";
+        $markupTwo = "<message><text-message>{user.message}</text-message></message>";
+
+        $message1 = new MessageTemplate();
+        $message1->setMessageMarkup($markupOne);
+
+        $message2 = new MessageTemplate();
+        $message2->setMessageMarkup($markupTwo);
+
+        MessageTemplateDataClient::shouldReceive('getAllMessageTemplates')
+            ->once()
+            ->andReturn(new MessageTemplateCollection([$message1, $message2]));
+
+        MessageTemplateDataClient::shouldReceive('updateMessageTemplate')->never();
+
+        \Artisan::call('attribute_message:update');
+    }
+
+    public function testUpdateSingleValidMessagesMessages()
+    {
+        $markupOne = "<message><attribute-message>user.dialogflow_message</attribute-message></message>";
+        $markupTwo = "<message><text-message>{user.message}</text-message></message>";
+        $markupThree = "<message>{user.dialogflow_message}</message>";
+
+        $message1 = new MessageTemplate();
+        $message1->setMessageMarkup($markupOne);
+
+        $message2 = new MessageTemplate();
+        $message2->setMessageMarkup($markupTwo);
+
+        $message3 = new MessageTemplate();
+        $message3->setMessageMarkup($markupThree);
+
+        MessageTemplateDataClient::shouldReceive('getAllMessageTemplates')
+            ->once()
+            ->andReturn(new MessageTemplateCollection([$message1, $message2, $message3]));
+
+        MessageTemplateDataClient::shouldReceive('updateMessageTemplate')->once();
+
+        \Artisan::call('attribute_message:update');
+    }
+
+    public function testUpdateMultipleValidMessagesMessages()
+    {
+        $markupOne = "<message><text-message>Before</text-message>{   user.dialogflow_message}</message>";
+        $markupTwo = "<message>{user.dialogflow_message  }<text-message>After</text-message></message>";
+        $markupThree =
+            "<message><text-message>Before</text-message>{ user.dialogflow_message }<text-message>After</text-message></message>";
+
+        $message1 = new MessageTemplate();
+        $message1->setMessageMarkup($markupOne);
+
+        $message2 = new MessageTemplate();
+        $message2->setMessageMarkup($markupTwo);
+
+        $message3 = new MessageTemplate();
+        $message3->setMessageMarkup($markupThree);
+
+        MessageTemplateDataClient::shouldReceive('getAllMessageTemplates')
+            ->once()
+            ->andReturn(new MessageTemplateCollection([$message1, $message2, $message3]));
+
+        MessageTemplateDataClient::shouldReceive('updateMessageTemplate')->times(3);
+
+        \Artisan::call('attribute_message:update');
+    }
+
+    public function testUpdateCheckContentOfUpdate()
+    {
+        $markup =
+            "<message><text-message>Before</text-message>{ user.dialogflow_message   }<text-message>After</text-message></message>";
+
+        $updatedMarkUp =
+            "<message><text-message>Before</text-message><attribute-message>user.dialogflow_message</attribute-message><text-message>After</text-message></message>";
+
+        $message = new MessageTemplate();
+        $message->setMessageMarkup($markup);
+
+        MessageTemplateDataClient::shouldReceive('getAllMessageTemplates')
+            ->once()
+            ->andReturn(new MessageTemplateCollection([$message]));
+
+        MessageTemplateDataClient::shouldReceive('updateMessageTemplate')
+            ->once()
+            ->with(\Mockery::on(function (MessageTemplate $messageTemplate) use ($updatedMarkUp) {
+                return $messageTemplate->getMessageMarkup() == $updatedMarkUp;
+            }));
+
+        \Artisan::call('attribute_message:update');
+    }
+}


### PR DESCRIPTION
This PR adds a new command that will search through all message templates in the graph, check for any use of `{user.dialogflow_message}` that is wrapped in an `<attribute-message>` and update it to be wrapped in one.

For example, if the message XML for a message was:

```
<message>
    {user.dialoglow_message}
    <text-message>Message Text</text-message>
</message>
```

The message template would be updated to:

```
<message>
    <attribute-message>user.dialoglow_message</attribute-message>
    <text-message>Message Text</text-message>
</message>
```

This change is required as the DialogFlow interpreter in core has been updated here https://github.com/opendialogai/core/pull/618 to be fully wrapped in OpenDialog message XML, so will no longer work by through standard attribute filling in messages, and must be parsed as an attribute message