### PR TITLE
Sets Cache-Control header to no-store for admin pages

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -6,6 +6,7 @@ class AdminController extends Controller
 {
     public function handle()
     {
-        return view('admin');
+        $contents = view('admin');
+        return response($contents)->header('Cache-Control', 'no-store');
     }
 }


### PR DESCRIPTION
This PR is to ensure that the admin pages are never served from cache in the browser by setting the cache-control header to `no-store` rather than `no-cache`